### PR TITLE
Feat/65/retrospect update

### DIFF
--- a/app/src/main/java/com/growit/app/goal/domain/goal/service/GoalService.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goal/service/GoalService.java
@@ -50,7 +50,7 @@ public class GoalService implements GoalValidator {
   @Override
   public void checkMyGoal(Goal goal, String userId) throws BadRequestException {
     if (!goal.getUserId().equals(userId)) {
-      throw new BadRequestException("삭제 권한이 없습니다.");
+      throw new BadRequestException("해당 정보가 올바르지 않습니다.");
     }
   }
 }

--- a/app/src/main/java/com/growit/app/retrospect/controller/RetrospectController.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/RetrospectController.java
@@ -28,7 +28,8 @@ public class RetrospectController {
   @PostMapping
   public ResponseEntity<ApiResponse<IdDto>> createRetrospect(
       @AuthenticationPrincipal User user, @Valid @RequestBody CreateRetrospectRequest request) {
-    CreateRetrospectCommand command = retrospectRequestMapper.toCreateCommand(user.getId(), request);
+    CreateRetrospectCommand command =
+        retrospectRequestMapper.toCreateCommand(user.getId(), request);
     String retrospectId = createRetrospectUseCase.execute(command);
 
     return ResponseEntity.status(HttpStatus.CREATED)
@@ -40,7 +41,8 @@ public class RetrospectController {
       @AuthenticationPrincipal User user,
       @PathVariable String id,
       @Valid @RequestBody UpdateRetrospectRequest request) {
-    UpdateRetrospectCommand command = retrospectRequestMapper.toUpdateCommand(user.getId(), id, request);
+    UpdateRetrospectCommand command =
+        retrospectRequestMapper.toUpdateCommand(id, user.getId(), request);
     updateRetrospectUseCase.execute(command);
 
     return ResponseEntity.ok().build();

--- a/app/src/main/java/com/growit/app/retrospect/controller/RetrospectController.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/RetrospectController.java
@@ -3,9 +3,12 @@ package com.growit.app.retrospect.controller;
 import com.growit.app.common.response.ApiResponse;
 import com.growit.app.common.response.IdDto;
 import com.growit.app.retrospect.controller.dto.request.CreateRetrospectRequest;
+import com.growit.app.retrospect.controller.dto.request.UpdateRetrospectRequest;
 import com.growit.app.retrospect.controller.mapper.RetrospectRequestMapper;
-import com.growit.app.retrospect.domain.retrospect.dto.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
 import com.growit.app.retrospect.usecase.CreateRetrospectUseCase;
+import com.growit.app.retrospect.usecase.UpdateRetrospectUseCase;
 import com.growit.app.user.domain.user.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,14 +23,26 @@ import org.springframework.web.bind.annotation.*;
 public class RetrospectController {
   private final CreateRetrospectUseCase createRetrospectUseCase;
   private final RetrospectRequestMapper retrospectRequestMapper;
+  private final UpdateRetrospectUseCase updateRetrospectUseCase;
 
   @PostMapping
   public ResponseEntity<ApiResponse<IdDto>> createRetrospect(
       @AuthenticationPrincipal User user, @Valid @RequestBody CreateRetrospectRequest request) {
-    CreateRetrospectCommand command = retrospectRequestMapper.toCommand(user.getId(), request);
+    CreateRetrospectCommand command = retrospectRequestMapper.toCreateCommand(user.getId(), request);
     String retrospectId = createRetrospectUseCase.execute(command);
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success(new IdDto(retrospectId)));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<Void> updateRetrospect(
+      @AuthenticationPrincipal User user,
+      @PathVariable String id,
+      @Valid @RequestBody UpdateRetrospectRequest request) {
+    UpdateRetrospectCommand command = retrospectRequestMapper.toUpdateCommand(user.getId(), id, request);
+    updateRetrospectUseCase.execute(command);
+
+    return ResponseEntity.ok().build();
   }
 }

--- a/app/src/main/java/com/growit/app/retrospect/controller/dto/request/UpdateRetrospectRequest.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/dto/request/UpdateRetrospectRequest.java
@@ -1,0 +1,14 @@
+package com.growit.app.retrospect.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateRetrospectRequest {
+  @NotBlank(message = "회고 내용은 필수입니다.")
+  @Size(min = 10, max = 200, message = "회고 내용은 10자 이상 200자 이하여야 합니다.")
+  private String content;
+}

--- a/app/src/main/java/com/growit/app/retrospect/controller/mapper/RetrospectRequestMapper.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/mapper/RetrospectRequestMapper.java
@@ -14,8 +14,8 @@ public class RetrospectRequestMapper {
         request.getGoalId(), request.getPlanId(), userId, request.getContent());
   }
 
-  public UpdateRetrospectCommand toUpdateCommand(String id, String userId, UpdateRetrospectRequest request) {
-    return new UpdateRetrospectCommand(
-      id, userId, request.getContent());
+  public UpdateRetrospectCommand toUpdateCommand(
+      String id, String userId, UpdateRetrospectRequest request) {
+    return new UpdateRetrospectCommand(id, userId, request.getContent());
   }
 }

--- a/app/src/main/java/com/growit/app/retrospect/controller/mapper/RetrospectRequestMapper.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/mapper/RetrospectRequestMapper.java
@@ -1,14 +1,21 @@
 package com.growit.app.retrospect.controller.mapper;
 
 import com.growit.app.retrospect.controller.dto.request.CreateRetrospectRequest;
-import com.growit.app.retrospect.domain.retrospect.dto.CreateRetrospectCommand;
+import com.growit.app.retrospect.controller.dto.request.UpdateRetrospectRequest;
+import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RetrospectRequestMapper {
 
-  public CreateRetrospectCommand toCommand(String userId, CreateRetrospectRequest request) {
+  public CreateRetrospectCommand toCreateCommand(String userId, CreateRetrospectRequest request) {
     return new CreateRetrospectCommand(
         request.getGoalId(), request.getPlanId(), userId, request.getContent());
+  }
+
+  public UpdateRetrospectCommand toUpdateCommand(String id, String userId, UpdateRetrospectRequest request) {
+    return new UpdateRetrospectCommand(
+      id, userId, request.getContent());
   }
 }

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/Retrospect.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/Retrospect.java
@@ -1,7 +1,8 @@
 package com.growit.app.retrospect.domain.retrospect;
 
 import com.growit.app.common.util.IDGenerator;
-import com.growit.app.retrospect.domain.retrospect.dto.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,5 +25,9 @@ public class Retrospect {
         .planId(command.planId())
         .content(command.content())
         .build();
+  }
+
+  public void updateBy(UpdateRetrospectCommand command) {
+    this.content = command.content();
   }
 }

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/RetrospectRepository.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/RetrospectRepository.java
@@ -5,5 +5,7 @@ import java.util.Optional;
 public interface RetrospectRepository {
   void saveRetrospect(Retrospect retrospect);
 
+  Optional<Retrospect> findById(String id);
+
   Optional<Retrospect> findByPlanId(String planId);
 }

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/command/CreateRetrospectCommand.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/command/CreateRetrospectCommand.java
@@ -1,4 +1,4 @@
-package com.growit.app.retrospect.domain.retrospect.dto;
+package com.growit.app.retrospect.domain.retrospect.command;
 
 public record CreateRetrospectCommand(
     String goalId, String planId, String userId, String content) {}

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/command/UpdateRetrospectCommand.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/command/UpdateRetrospectCommand.java
@@ -1,0 +1,4 @@
+package com.growit.app.retrospect.domain.retrospect.command;
+
+public record UpdateRetrospectCommand(
+    String id, String userId, String content) {}

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/command/UpdateRetrospectCommand.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/command/UpdateRetrospectCommand.java
@@ -1,4 +1,3 @@
 package com.growit.app.retrospect.domain.retrospect.command;
 
-public record UpdateRetrospectCommand(
-    String id, String userId, String content) {}
+public record UpdateRetrospectCommand(String id, String userId, String content) {}

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/service/RetrospectService.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/service/RetrospectService.java
@@ -1,6 +1,7 @@
 package com.growit.app.retrospect.domain.retrospect.service;
 
 import com.growit.app.common.exception.BadRequestException;
+import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import com.growit.app.retrospect.domain.retrospect.RetrospectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,5 +19,12 @@ public class RetrospectService implements RetrospectValidator {
             existing -> {
               throw new BadRequestException("해당 주간 계획에 대한 회고가 이미 존재합니다.");
             });
+  }
+
+  @Override
+  public void checkMyRetrospect(Retrospect retrospect, String userId) throws BadRequestException {
+    if (!retrospect.getUserId().equals(userId)) {
+      throw new BadRequestException("해당 정보가 올바르지 않습니다.");
+    }
   }
 }

--- a/app/src/main/java/com/growit/app/retrospect/domain/retrospect/service/RetrospectValidator.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/retrospect/service/RetrospectValidator.java
@@ -1,7 +1,10 @@
 package com.growit.app.retrospect.domain.retrospect.service;
 
 import com.growit.app.common.exception.BadRequestException;
+import com.growit.app.retrospect.domain.retrospect.Retrospect;
 
 public interface RetrospectValidator {
   void checkUniqueRetrospect(String planId) throws BadRequestException;
+
+  void checkMyRetrospect(Retrospect retrospect, String userId) throws BadRequestException;
 }

--- a/app/src/main/java/com/growit/app/retrospect/infrastructure/persistence/retrospect/RetrospectRepositoryImpl.java
+++ b/app/src/main/java/com/growit/app/retrospect/infrastructure/persistence/retrospect/RetrospectRepositoryImpl.java
@@ -28,6 +28,12 @@ public class RetrospectRepositoryImpl implements RetrospectRepository {
   }
 
   @Override
+  public Optional<Retrospect> findById(String id) {
+    Optional<RetrospectEntity> entity = repository.findByUid(id);
+    return entity.map(mapper::toDomain);
+  }
+
+  @Override
   public Optional<Retrospect> findByPlanId(String planId) {
     Optional<RetrospectEntity> entity = repository.findByPlanId(planId);
     return entity.map(mapper::toDomain);

--- a/app/src/main/java/com/growit/app/retrospect/usecase/UpdateRetrospectUseCase.java
+++ b/app/src/main/java/com/growit/app/retrospect/usecase/UpdateRetrospectUseCase.java
@@ -1,11 +1,8 @@
 package com.growit.app.retrospect.usecase;
 
 import com.growit.app.common.exception.NotFoundException;
-import com.growit.app.goal.domain.goal.Goal;
-import com.growit.app.goal.domain.goal.service.GoalValidator;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import com.growit.app.retrospect.domain.retrospect.RetrospectRepository;
-import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
 import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
 import com.growit.app.retrospect.domain.retrospect.service.RetrospectValidator;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +17,10 @@ public class UpdateRetrospectUseCase {
 
   @Transactional
   public void execute(UpdateRetrospectCommand command) {
-    Retrospect retrospect = retrospectRepository.findById(command.id())
-      .orElseThrow(() -> new NotFoundException("회고 정보가 존재하지 않습니다."));
+    Retrospect retrospect =
+        retrospectRepository
+            .findById(command.id())
+            .orElseThrow(() -> new NotFoundException("회고 정보가 존재하지 않습니다."));
 
     retrospectValidator.checkMyRetrospect(retrospect, command.userId());
 

--- a/app/src/main/java/com/growit/app/retrospect/usecase/UpdateRetrospectUseCase.java
+++ b/app/src/main/java/com/growit/app/retrospect/usecase/UpdateRetrospectUseCase.java
@@ -1,9 +1,12 @@
 package com.growit.app.retrospect.usecase;
 
+import com.growit.app.common.exception.NotFoundException;
+import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.goal.domain.goal.service.GoalValidator;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import com.growit.app.retrospect.domain.retrospect.RetrospectRepository;
 import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
 import com.growit.app.retrospect.domain.retrospect.service.RetrospectValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,23 +14,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class CreateRetrospectUseCase {
-  private final GoalValidator goalValidator;
+public class UpdateRetrospectUseCase {
   private final RetrospectValidator retrospectValidator;
   private final RetrospectRepository retrospectRepository;
 
   @Transactional
-  public String execute(CreateRetrospectCommand command) {
-    // 계획 존재 여부 확인
-    goalValidator.checkPlanExists(command.userId(), command.goalId(), command.planId());
+  public void execute(UpdateRetrospectCommand command) {
+    Retrospect retrospect = retrospectRepository.findById(command.id())
+      .orElseThrow(() -> new NotFoundException("회고 정보가 존재하지 않습니다."));
 
-    // 이미 회고가 존재하는지 확인
-    retrospectValidator.checkUniqueRetrospect(command.planId());
+    retrospectValidator.checkMyRetrospect(retrospect, command.userId());
 
-    // 회고 생성 및 저장
-    Retrospect retrospect = Retrospect.from(command);
+    retrospect.updateBy(command);
     retrospectRepository.saveRetrospect(retrospect);
-
-    return retrospect.getId();
   }
 }

--- a/app/src/main/resources/static/docs/swagger-spec.js
+++ b/app/src/main/resources/static/docs/swagger-spec.js
@@ -168,7 +168,7 @@ window.swaggerSpec={
                 },
                 "examples" : {
                   "create-goal" : {
-                    "value" : "{\n  \"data\" : {\n    \"id\" : \"FiXILZhfEXC52bvHgcdbm\"\n  }\n}"
+                    "value" : "{\n  \"data\" : {\n    \"id\" : \"M4Cz_oIYw5jlYxoz8RYwo\"\n  }\n}"
                   }
                 }
               }
@@ -275,6 +275,42 @@ window.swaggerSpec={
         }
       }
     },
+    "/retrospects/{id}" : {
+      "put" : {
+        "tags" : [ "Retrospects" ],
+        "summary" : "회고 수정",
+        "description" : "회고 수정",
+        "operationId" : "update-retrospect",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "회고 ID",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/retrospects-id130578538"
+              },
+              "examples" : {
+                "update-retrospect" : {
+                  "value" : "{\n  \"content\" : \"이번 주에는 계획한 목표를 달성하기 위해 열심히 노력했습니다. 특히 새로운 기술을 배우는 것에 집중했습니다.\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200"
+          }
+        }
+      }
+    },
     "/users/myprofile" : {
       "get" : {
         "tags" : [ "User" ],
@@ -313,82 +349,12 @@ window.swaggerSpec={
   },
   "components" : {
     "schemas" : {
-      "goals595146955" : {
+      "retrospects-id130578538" : {
         "type" : "object",
         "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "duration" : {
-                  "type" : "object",
-                  "properties" : {
-                    "endDate" : {
-                      "type" : "string",
-                      "description" : "종료일 (yyyy-MM-dd)"
-                    },
-                    "startDate" : {
-                      "type" : "string",
-                      "description" : "시작일 (yyyy-MM-dd)"
-                    }
-                  },
-                  "description" : "기간 정보 객체"
-                },
-                "plans" : {
-                  "type" : "array",
-                  "description" : "계획 리스트",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "weekOfMonth" : {
-                        "type" : "number",
-                        "description" : "주차"
-                      },
-                      "id" : {
-                        "type" : "string",
-                        "description" : "계획 ID"
-                      },
-                      "content" : {
-                        "type" : "string",
-                        "description" : "계획 내용"
-                      }
-                    }
-                  }
-                },
-                "name" : {
-                  "type" : "string",
-                  "description" : "목표 이름"
-                },
-                "id" : {
-                  "type" : "string",
-                  "description" : "목표 ID"
-                },
-                "beforeAfter" : {
-                  "type" : "object",
-                  "properties" : {
-                    "asIs" : {
-                      "type" : "string",
-                      "description" : "현재 상태(As-Is)"
-                    },
-                    "toBe" : {
-                      "type" : "string",
-                      "description" : "목표 달성 후 상태(To-Be)"
-                    }
-                  },
-                  "description" : "전/후 상태 정보 객체"
-                }
-              }
-            }
-          }
-        }
-      },
-      "auth-reissue356149288" : {
-        "type" : "object",
-        "properties" : {
-          "refreshToken" : {
+          "content" : {
             "type" : "string",
-            "description" : "리프레시 토큰"
+            "description" : "회고 내용"
           }
         }
       },
@@ -427,24 +393,6 @@ window.swaggerSpec={
           "email" : {
             "type" : "string",
             "description" : "사용자 이메일"
-          }
-        }
-      },
-      "auth-reissue-424105652" : {
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "object",
-            "properties" : {
-              "accessToken" : {
-                "type" : "string",
-                "description" : "엑세스 토큰"
-              },
-              "refreshToken" : {
-                "type" : "string",
-                "description" : "리프레시 토큰"
-              }
-            }
           }
         }
       },
@@ -534,20 +482,6 @@ window.swaggerSpec={
           }
         }
       },
-      "goals574842772" : {
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "object",
-            "properties" : {
-              "id" : {
-                "type" : "string",
-                "description" : "목표 ID"
-              }
-            }
-          }
-        }
-      },
       "retrospects-1554052329" : {
         "type" : "object",
         "properties" : {
@@ -557,6 +491,134 @@ window.swaggerSpec={
               "id" : {
                 "type" : "string",
                 "description" : "회고 ID"
+              }
+            }
+          }
+        }
+      },
+      "retrospects-597490674" : {
+        "type" : "object",
+        "properties" : {
+          "goalId" : {
+            "type" : "string",
+            "description" : "목표 아이디"
+          },
+          "planId" : {
+            "type" : "string",
+            "description" : "계획 아이디"
+          },
+          "content" : {
+            "type" : "string",
+            "description" : "회고 내용"
+          }
+        }
+      },
+      "goals595146955" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "duration" : {
+                  "type" : "object",
+                  "properties" : {
+                    "endDate" : {
+                      "type" : "string",
+                      "description" : "종료일 (yyyy-MM-dd)"
+                    },
+                    "startDate" : {
+                      "type" : "string",
+                      "description" : "시작일 (yyyy-MM-dd)"
+                    }
+                  },
+                  "description" : "기간 정보 객체"
+                },
+                "plans" : {
+                  "type" : "array",
+                  "description" : "계획 리스트",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "weekOfMonth" : {
+                        "type" : "number",
+                        "description" : "주차"
+                      },
+                      "id" : {
+                        "type" : "string",
+                        "description" : "계획 ID"
+                      },
+                      "content" : {
+                        "type" : "string",
+                        "description" : "계획 내용"
+                      }
+                    }
+                  }
+                },
+                "name" : {
+                  "type" : "string",
+                  "description" : "목표 이름"
+                },
+                "id" : {
+                  "type" : "string",
+                  "description" : "목표 ID"
+                },
+                "beforeAfter" : {
+                  "type" : "object",
+                  "properties" : {
+                    "asIs" : {
+                      "type" : "string",
+                      "description" : "현재 상태(As-Is)"
+                    },
+                    "toBe" : {
+                      "type" : "string",
+                      "description" : "목표 달성 후 상태(To-Be)"
+                    }
+                  },
+                  "description" : "전/후 상태 정보 객체"
+                }
+              }
+            }
+          }
+        }
+      },
+      "auth-reissue356149288" : {
+        "type" : "object",
+        "properties" : {
+          "refreshToken" : {
+            "type" : "string",
+            "description" : "리프레시 토큰"
+          }
+        }
+      },
+      "auth-reissue-424105652" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "accessToken" : {
+                "type" : "string",
+                "description" : "엑세스 토큰"
+              },
+              "refreshToken" : {
+                "type" : "string",
+                "description" : "리프레시 토큰"
+              }
+            }
+          }
+        }
+      },
+      "goals574842772" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "string",
+                "description" : "목표 ID"
               }
             }
           }
@@ -611,23 +673,6 @@ window.swaggerSpec={
           "email" : {
             "type" : "string",
             "description" : "사용자 이메일"
-          }
-        }
-      },
-      "retrospects-597490674" : {
-        "type" : "object",
-        "properties" : {
-          "goalId" : {
-            "type" : "string",
-            "description" : "목표 아이디"
-          },
-          "planId" : {
-            "type" : "string",
-            "description" : "계획 아이디"
-          },
-          "content" : {
-            "type" : "string",
-            "description" : "회고 내용"
           }
         }
       }

--- a/app/src/test/java/com/growit/app/fake/retrospect/FakeRetrospectRepository.java
+++ b/app/src/test/java/com/growit/app/fake/retrospect/FakeRetrospectRepository.java
@@ -14,6 +14,11 @@ public class FakeRetrospectRepository implements RetrospectRepository {
   }
 
   @Override
+  public Optional<Retrospect> findById(String id) {
+    return Optional.ofNullable(store.get(id));
+  }
+
+  @Override
   public Optional<Retrospect> findByPlanId(String planId) {
     return store.values().stream().filter(r -> r.getPlanId().equals(planId)).findFirst();
   }

--- a/app/src/test/java/com/growit/app/fake/retrospect/RetrospectFixture.java
+++ b/app/src/test/java/com/growit/app/fake/retrospect/RetrospectFixture.java
@@ -1,8 +1,10 @@
 package com.growit.app.fake.retrospect;
 
 import com.growit.app.retrospect.controller.dto.request.CreateRetrospectRequest;
+import com.growit.app.retrospect.controller.dto.request.UpdateRetrospectRequest;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
 
 public class RetrospectFixture {
   public static Retrospect defaultRetrospect() {
@@ -25,6 +27,21 @@ public class RetrospectFixture {
   public static CreateRetrospectCommand createRetrospectCommandWithContent(
       String goalId, String userId, String planId, String content) {
     return new CreateRetrospectCommand(goalId, planId, userId, content);
+  }
+
+  public static UpdateRetrospectRequest defaultUpdateRetrospectRequest() {
+    return new UpdateRetrospectRequest(
+        "이번 주에는 계획한 목표를 달성하기 위해 열심히 노력했습니다. 특히 새로운 기술을 배우는 것에 집중했습니다.");
+  }
+
+  public static UpdateRetrospectCommand defaultUpdateRetrospectCommand() {
+    return new UpdateRetrospectCommand(
+        "id", "userId", "이번 주에는 계획한 목표를 달성하기 위해 열심히 노력했습니다. 특히 새로운 기술을 배우는 것에 집중했습니다.");
+  }
+
+  public static UpdateRetrospectCommand updateRetrospectCommand(
+      String id, String userId, String content) {
+    return new UpdateRetrospectCommand(id, userId, content);
   }
 }
 

--- a/app/src/test/java/com/growit/app/fake/retrospect/RetrospectFixture.java
+++ b/app/src/test/java/com/growit/app/fake/retrospect/RetrospectFixture.java
@@ -2,7 +2,7 @@ package com.growit.app.fake.retrospect;
 
 import com.growit.app.retrospect.controller.dto.request.CreateRetrospectRequest;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
-import com.growit.app.retrospect.domain.retrospect.dto.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
 
 public class RetrospectFixture {
   public static Retrospect defaultRetrospect() {

--- a/app/src/test/java/com/growit/app/retrospect/controller/RetrospectControllerTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/controller/RetrospectControllerTest.java
@@ -8,7 +8,9 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
@@ -16,7 +18,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.growit.app.common.TestSecurityUtil;
 import com.growit.app.fake.retrospect.RetrospectFixture;
 import com.growit.app.retrospect.controller.dto.request.CreateRetrospectRequest;
+import com.growit.app.retrospect.controller.dto.request.UpdateRetrospectRequest;
 import com.growit.app.retrospect.usecase.CreateRetrospectUseCase;
+import com.growit.app.retrospect.usecase.UpdateRetrospectUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +46,7 @@ class RetrospectControllerTest {
   @Autowired private ObjectMapper objectMapper;
 
   @MockitoBean private CreateRetrospectUseCase createRetrospectUseCase;
+  @MockitoBean private UpdateRetrospectUseCase updateRetrospectUseCase;
 
   @BeforeEach
   void setUp(
@@ -87,6 +92,33 @@ class RetrospectControllerTest {
                                 .type(JsonFieldType.STRING)
                                 .description("회고 내용"))
                         .responseFields(fieldWithPath("data.id").type(STRING).description("회고 ID"))
+                        .build())));
+  }
+
+  @Test
+  void updateRetrospect() throws Exception {
+    UpdateRetrospectRequest body = RetrospectFixture.defaultUpdateRetrospectRequest();
+    mockMvc
+        .perform(
+            put("/retrospects/{id}", "retrospect-id")
+                .header("Authorization", "Bearer mock-jwt-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "update-retrospect",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    new ResourceSnippetParametersBuilder()
+                        .tag("Retrospects")
+                        .summary("회고 수정")
+                        .pathParameters(parameterWithName("id").description("회고 ID"))
+                        .requestFields(
+                            fieldWithPath("content")
+                                .type(JsonFieldType.STRING)
+                                .description("회고 내용"))
                         .build())));
   }
 }

--- a/app/src/test/java/com/growit/app/retrospect/domain/retrospect/RetrospectTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/domain/retrospect/RetrospectTest.java
@@ -24,23 +24,4 @@ class RetrospectTest {
     assertEquals(command.planId(), retrospect.getPlanId());
     assertEquals(command.content(), retrospect.getContent());
   }
-
-  @Test
-  void givenRetrospectBuilder_whenBuild_thenRetrospectIsCreated() {
-    // Given & When
-    Retrospect retrospect =
-        Retrospect.builder()
-            .id("test-id")
-            .userId("user-id")
-            .goalId("goal-123")
-            .planId("plan-456")
-            .content("Test retrospect content")
-            .build();
-
-    // Then
-    assertEquals("test-id", retrospect.getId());
-    assertEquals("goal-123", retrospect.getGoalId());
-    assertEquals("plan-456", retrospect.getPlanId());
-    assertEquals("Test retrospect content", retrospect.getContent());
-  }
 }

--- a/app/src/test/java/com/growit/app/retrospect/domain/retrospect/RetrospectTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/domain/retrospect/RetrospectTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.growit.app.fake.retrospect.RetrospectFixture;
-import com.growit.app.retrospect.domain.retrospect.dto.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
 import org.junit.jupiter.api.Test;
 
 class RetrospectTest {

--- a/app/src/test/java/com/growit/app/retrospect/domain/retrospect/service/RetrospectServiceTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/domain/retrospect/service/RetrospectServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.growit.app.common.exception.BadRequestException;
 import com.growit.app.fake.retrospect.FakeRetrospectRepository;
+import com.growit.app.fake.retrospect.RetrospectFixture;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,30 +24,40 @@ class RetrospectServiceTest {
 
   @Test
   void givenExistingRetrospect_whenCheckUniqueRetrospect_throwBadRequestException() {
-    Retrospect existingRetrospect =
-        Retrospect.builder()
-            .id("existing-id")
-            .goalId("goal-123")
-            .planId("plan-456")
-            .content("기존 회고")
-            .build();
+    Retrospect existingRetrospect = RetrospectFixture.defaultRetrospect();
     retrospectRepository.saveRetrospect(existingRetrospect);
 
     assertThrows(
-        BadRequestException.class, () -> retrospectService.checkUniqueRetrospect("plan-456"));
+        BadRequestException.class,
+        () -> retrospectService.checkUniqueRetrospect(existingRetrospect.getPlanId()));
   }
 
   @Test
   void givenNoExistingRetrospect_whenCheckUniqueRetrospect_thenSuccess() {
-    Retrospect existingRetrospect =
-        Retrospect.builder()
-            .id("existing-id")
-            .goalId("goal-123")
-            .planId("plan-456")
-            .content("기존 회고")
-            .build();
+    Retrospect existingRetrospect = RetrospectFixture.defaultRetrospect();
     retrospectRepository.saveRetrospect(existingRetrospect);
 
-    assertDoesNotThrow(() -> retrospectService.checkUniqueRetrospect("planId"));
+    assertDoesNotThrow(() -> retrospectService.checkUniqueRetrospect("newPlanId"));
+  }
+
+  @Test
+  void givenMismatchedUserId_whenCheckMyRetrospect_thenThrowsBadRequestException() {
+    // Given
+    Retrospect retrospect = RetrospectFixture.defaultRetrospect();
+
+    // When & Then
+    assertThrows(
+        BadRequestException.class,
+        () -> retrospectService.checkMyRetrospect(retrospect, "invalidUserId"));
+  }
+
+  @Test
+  void givenMatchingUserId_whenCheckMyRetrospect_thenDoesNotThrow() {
+    // Given
+    Retrospect retrospect = RetrospectFixture.defaultRetrospect();
+
+    // When & Then
+    assertDoesNotThrow(
+        () -> retrospectService.checkMyRetrospect(retrospect, retrospect.getUserId()));
   }
 }

--- a/app/src/test/java/com/growit/app/retrospect/usecase/CreateRetrospectUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/usecase/CreateRetrospectUseCaseTest.java
@@ -9,7 +9,7 @@ import com.growit.app.fake.retrospect.RetrospectFixture;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.goal.domain.goal.service.GoalService;
 import com.growit.app.goal.domain.goal.service.GoalValidator;
-import com.growit.app.retrospect.domain.retrospect.dto.CreateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.command.CreateRetrospectCommand;
 import com.growit.app.retrospect.domain.retrospect.service.RetrospectService;
 import com.growit.app.retrospect.domain.retrospect.service.RetrospectValidator;
 import org.junit.jupiter.api.BeforeEach;

--- a/app/src/test/java/com/growit/app/retrospect/usecase/UpdateRetrospectUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/usecase/UpdateRetrospectUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.growit.app.retrospect.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.growit.app.common.exception.BadRequestException;
+import com.growit.app.common.exception.NotFoundException;
+import com.growit.app.fake.retrospect.FakeRetrospectRepository;
+import com.growit.app.fake.retrospect.RetrospectFixture;
+import com.growit.app.retrospect.domain.retrospect.Retrospect;
+import com.growit.app.retrospect.domain.retrospect.command.UpdateRetrospectCommand;
+import com.growit.app.retrospect.domain.retrospect.service.RetrospectService;
+import com.growit.app.retrospect.domain.retrospect.service.RetrospectValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UpdateRetrospectUseCaseTest {
+
+  private UpdateRetrospectUseCase updateRetrospectUseCase;
+  private FakeRetrospectRepository retrospectRepository;
+
+  @BeforeEach
+  void setUp() {
+    retrospectRepository = new FakeRetrospectRepository();
+    RetrospectValidator retrospectValidator = new RetrospectService(retrospectRepository);
+    updateRetrospectUseCase =
+        new UpdateRetrospectUseCase(retrospectValidator, retrospectRepository);
+  }
+
+  @Test
+  void givenNotExistRetrospect_whenExecute_thenReturnsNotFoundException() {
+    // Given
+    UpdateRetrospectCommand command =
+        RetrospectFixture.updateRetrospectCommand("id", "userId", "이번 주");
+    // Then
+    assertThrows(NotFoundException.class, () -> updateRetrospectUseCase.execute(command));
+  }
+
+  @Test
+  void givenInvalidCommand_whenExecute_thenReturnsBadRequestException() {
+    // Given
+    Retrospect retrospect = RetrospectFixture.defaultRetrospect();
+    retrospectRepository.saveRetrospect(retrospect);
+
+    UpdateRetrospectCommand command =
+        RetrospectFixture.updateRetrospectCommand(retrospect.getId(), "invalidUserId", "이번 주");
+    // Then
+    assertThrows(BadRequestException.class, () -> updateRetrospectUseCase.execute(command));
+  }
+}


### PR DESCRIPTION
## 📌 PR 제목

> feat: 회고 수정 기능 구현

---

## ✅ PR 설명

- 회고 수정기능을 추가합니다. 
- 기존 전체 dto 에서 content 만 받아서 수정하는 방향으로 변경 하였습니다. 
- 관련 이슈: #65  
---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
