### PR TITLE
Feat/72/todo status

### DIFF
--- a/app/src/main/java/com/growit/app/todos/controller/dto/CompletedStatusChangeRequest.java
+++ b/app/src/main/java/com/growit/app/todos/controller/dto/CompletedStatusChangeRequest.java
@@ -1,12 +1,12 @@
 package com.growit.app.todos.controller.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class CompletedStatusChangeRequest {
-  @NotBlank(message = "할일 상태값은 필수입니다.")
+  @JsonProperty("isCompleted")
   private boolean isCompleted;
 }

--- a/app/src/main/java/com/growit/app/todos/controller/dto/CompletedStatusChangeRequest.java
+++ b/app/src/main/java/com/growit/app/todos/controller/dto/CompletedStatusChangeRequest.java
@@ -8,5 +8,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CompletedStatusChangeRequest {
   @JsonProperty("isCompleted")
-  private boolean isCompleted;
+  private boolean completed;
 }

--- a/app/src/main/java/com/growit/app/todos/domain/ToDoRepository.java
+++ b/app/src/main/java/com/growit/app/todos/domain/ToDoRepository.java
@@ -12,5 +12,5 @@ public interface ToDoRepository {
 
   Optional<ToDo> findById(String id);
 
-  void setIsCompleted(String id, boolean isCompleted);
+  void updateCompletedStatus(String id, boolean isCompleted);
 }

--- a/app/src/main/java/com/growit/app/todos/domain/ToDoRepository.java
+++ b/app/src/main/java/com/growit/app/todos/domain/ToDoRepository.java
@@ -11,6 +11,4 @@ public interface ToDoRepository {
   int countByToDoWithToDoId(LocalDate date, String userId, String planId, String id);
 
   Optional<ToDo> findById(String id);
-
-  void updateCompletedStatus(String id, boolean completed);
 }

--- a/app/src/main/java/com/growit/app/todos/domain/ToDoRepository.java
+++ b/app/src/main/java/com/growit/app/todos/domain/ToDoRepository.java
@@ -12,5 +12,5 @@ public interface ToDoRepository {
 
   Optional<ToDo> findById(String id);
 
-  void updateCompletedStatus(String id, boolean isCompleted);
+  void updateCompletedStatus(String id, boolean completed);
 }

--- a/app/src/main/java/com/growit/app/todos/domain/dto/CompletedStatusChangeCommand.java
+++ b/app/src/main/java/com/growit/app/todos/domain/dto/CompletedStatusChangeCommand.java
@@ -1,3 +1,3 @@
 package com.growit.app.todos.domain.dto;
 
-public record CompletedStatusChangeCommand(String id, String userId, boolean isCompleted) {}
+public record CompletedStatusChangeCommand(String id, String userId, boolean completed) {}

--- a/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
+++ b/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
@@ -46,10 +46,10 @@ public class ToDoRepositoryImpl implements ToDoRepository {
   }
 
   @Override
-  public void updateCompletedStatus(String id, boolean isCompleted) {
+  public void updateCompletedStatus(String id, boolean completed) {
     ToDoEntity entity =
         repository.findByUid(id).orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
-    entity.updateCompleted(isCompleted);
+    entity.updateCompleted(completed);
     repository.save(entity);
   }
 }

--- a/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
+++ b/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
@@ -21,7 +21,6 @@ public class ToDoRepositoryImpl implements ToDoRepository {
     if (existing.isPresent()) {
       ToDoEntity entity = existing.get();
       entity.updateToByDomain(toDo);
-      entity.updateCompleted(toDo.isCompleted());
       repository.save(entity);
     } else {
       ToDoEntity toDoEntity = mapper.toEntity(toDo);

--- a/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
+++ b/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
@@ -22,7 +22,6 @@ public class ToDoRepositoryImpl implements ToDoRepository {
     if (existing.isPresent()) {
       ToDoEntity entity = existing.get();
       entity.updateToByDomain(toDo);
-      entity.updateCompleted(toDo);
       repository.save(entity);
     } else {
       ToDoEntity toDoEntity = mapper.toEntity(toDo);
@@ -47,10 +46,10 @@ public class ToDoRepositoryImpl implements ToDoRepository {
   }
 
   @Override
-  public void setIsCompleted(String id, boolean isCompleted) {
+  public void updateCompletedStatus(String id, boolean isCompleted) {
     ToDoEntity entity =
         repository.findByUid(id).orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
-    entity.setCompleted(isCompleted);
+    entity.updateCompleted(isCompleted);
     repository.save(entity);
   }
 }

--- a/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
+++ b/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/ToDoRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.growit.app.todos.infrastructure.persistence.todos;
 
-import com.growit.app.common.exception.NotFoundException;
 import com.growit.app.todos.domain.ToDo;
 import com.growit.app.todos.domain.ToDoRepository;
 import com.growit.app.todos.infrastructure.persistence.todos.source.DBToDoRepository;
@@ -22,6 +21,7 @@ public class ToDoRepositoryImpl implements ToDoRepository {
     if (existing.isPresent()) {
       ToDoEntity entity = existing.get();
       entity.updateToByDomain(toDo);
+      entity.updateCompleted(toDo.isCompleted());
       repository.save(entity);
     } else {
       ToDoEntity toDoEntity = mapper.toEntity(toDo);
@@ -43,13 +43,5 @@ public class ToDoRepositoryImpl implements ToDoRepository {
   public Optional<ToDo> findById(String id) {
     Optional<ToDoEntity> entity = repository.findByUid(id);
     return entity.map(mapper::toDomain);
-  }
-
-  @Override
-  public void updateCompletedStatus(String id, boolean completed) {
-    ToDoEntity entity =
-        repository.findByUid(id).orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
-    entity.updateCompleted(completed);
-    repository.save(entity);
   }
 }

--- a/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/source/entity/ToDoEntity.java
+++ b/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/source/entity/ToDoEntity.java
@@ -39,9 +39,6 @@ public class ToDoEntity extends BaseEntity {
   public void updateToByDomain(ToDo toDo) {
     this.date = toDo.getDate();
     this.content = toDo.getContent();
-  }
-
-  public void updateCompleted(boolean isCompleted) {
-    this.isCompleted = isCompleted;
+    this.isCompleted = toDo.isCompleted();
   }
 }

--- a/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/source/entity/ToDoEntity.java
+++ b/app/src/main/java/com/growit/app/todos/infrastructure/persistence/todos/source/entity/ToDoEntity.java
@@ -11,7 +11,6 @@ import lombok.*;
 @Entity
 @Table(name = "todos")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -42,7 +41,7 @@ public class ToDoEntity extends BaseEntity {
     this.content = toDo.getContent();
   }
 
-  public void updateCompleted(ToDo todo) {
-    this.isCompleted = todo.isCompleted();
+  public void updateCompleted(boolean isCompleted) {
+    this.isCompleted = isCompleted;
   }
 }

--- a/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
+++ b/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
@@ -20,7 +20,7 @@ public class CompletedStatusChangeToDoUseCase {
             .findById(command.id())
             .orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
     toDo.isCompleted(command.completed());
-
-    toDoRepository.updateCompletedStatus(command.id(), command.completed());
+    System.out.println("isCompleted :: " + toDo.isCompleted());
+    toDoRepository.saveToDo(toDo);
   }
 }

--- a/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
+++ b/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
@@ -19,8 +19,8 @@ public class CompletedStatusChangeToDoUseCase {
         toDoRepository
             .findById(command.id())
             .orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
-    toDo.isCompleted(command.isCompleted());
+    toDo.isCompleted(command.completed());
 
-    toDoRepository.updateCompletedStatus(command.id(), command.isCompleted());
+    toDoRepository.updateCompletedStatus(command.id(), command.completed());
   }
 }

--- a/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
+++ b/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
@@ -20,6 +20,7 @@ public class CompletedStatusChangeToDoUseCase {
             .findById(command.id())
             .orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
     toDo.isCompleted(command.isCompleted());
-    toDoRepository.setIsCompleted(command.id(), command.isCompleted());
+
+    toDoRepository.updateCompletedStatus(command.id(), command.isCompleted());
   }
 }

--- a/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
+++ b/app/src/main/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCase.java
@@ -20,7 +20,6 @@ public class CompletedStatusChangeToDoUseCase {
             .findById(command.id())
             .orElseThrow(() -> new NotFoundException("할 일 정보가 존재하지 않습니다."));
     toDo.isCompleted(command.completed());
-    System.out.println("isCompleted :: " + toDo.isCompleted());
     toDoRepository.saveToDo(toDo);
   }
 }

--- a/app/src/test/java/com/growit/app/fake/todos/FakeToDoRepository.java
+++ b/app/src/test/java/com/growit/app/fake/todos/FakeToDoRepository.java
@@ -53,9 +53,6 @@ public class FakeToDoRepository implements ToDoRepository {
         .findFirst();
   }
 
-  @Override
-  public void updateCompletedStatus(String id, boolean completed) {}
-
   public void clear() {
     store.clear();
   }

--- a/app/src/test/java/com/growit/app/fake/todos/FakeToDoRepository.java
+++ b/app/src/test/java/com/growit/app/fake/todos/FakeToDoRepository.java
@@ -54,7 +54,7 @@ public class FakeToDoRepository implements ToDoRepository {
   }
 
   @Override
-  public void setIsCompleted(String id, boolean isCompleted) {}
+  public void updateCompletedStatus(String id, boolean isCompleted) {}
 
   public void clear() {
     store.clear();

--- a/app/src/test/java/com/growit/app/fake/todos/FakeToDoRepository.java
+++ b/app/src/test/java/com/growit/app/fake/todos/FakeToDoRepository.java
@@ -54,7 +54,7 @@ public class FakeToDoRepository implements ToDoRepository {
   }
 
   @Override
-  public void updateCompletedStatus(String id, boolean isCompleted) {}
+  public void updateCompletedStatus(String id, boolean completed) {}
 
   public void clear() {
     store.clear();

--- a/app/src/test/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCaseTest.java
@@ -1,0 +1,60 @@
+package com.growit.app.todos.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.growit.app.common.exception.NotFoundException;
+import com.growit.app.fake.todos.FakeToDoRepository;
+import com.growit.app.fake.todos.ToDoFixture;
+import com.growit.app.todos.domain.ToDo;
+import com.growit.app.todos.domain.dto.CompletedStatusChangeCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CompletedStatusChangeToDoUseCaseTest {
+
+  private CompletedStatusChangeToDoUseCase useCase;
+  private FakeToDoRepository fakeToDoRepository;
+
+  @BeforeEach
+  void setUp() {
+    fakeToDoRepository = new FakeToDoRepository();
+    useCase = new CompletedStatusChangeToDoUseCase(fakeToDoRepository);
+
+    // ToDoFixture에서 기본 데이터 추가
+    ToDo todo = ToDoFixture.defaultToDo();
+    fakeToDoRepository.saveToDo(todo);
+  }
+
+  @Test
+  void givenValidTodo_whenExecute_thenStatusIsChanged() {
+    // given
+    ToDo todo = fakeToDoRepository.findById("todo-1").get();
+    String todoId = todo.getId();
+    String userId = todo.getUserId();
+
+    CompletedStatusChangeCommand command = new CompletedStatusChangeCommand(todoId, userId, true);
+
+    // when
+    useCase.execute(command);
+
+    // then
+    ToDo updated = fakeToDoRepository.findById(todoId).get();
+    assertThat(updated.isCompleted()).isTrue();
+  }
+
+  @Test
+  void givenNonExistingTodo_whenExecute_thenThrowsNotFoundException() {
+    // given
+    String notExistId = "not-exist";
+    String userId = "user-1";
+
+    CompletedStatusChangeCommand command =
+        new CompletedStatusChangeCommand(notExistId, userId, true);
+
+    // when & then
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("할 일 정보가 존재하지 않습니다.");
+  }
+}

--- a/app/src/test/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todos/usecase/CompletedStatusChangeToDoUseCaseTest.java
@@ -21,7 +21,6 @@ class CompletedStatusChangeToDoUseCaseTest {
     fakeToDoRepository = new FakeToDoRepository();
     useCase = new CompletedStatusChangeToDoUseCase(fakeToDoRepository);
 
-    // ToDoFixture에서 기본 데이터 추가
     ToDo todo = ToDoFixture.defaultToDo();
     fakeToDoRepository.saveToDo(todo);
   }


### PR DESCRIPTION
## 📌 PR 제목

> ToDo 완료 상태 업데이트 기능 구현

---

## ✅ PR 설명

- ToDo의 완료 상태를 isComplete: boolean 값으로 업데이트 한다
- 관련 이슈: #72 

---

## 🧪 테스트 방법

- [ ] 로컬 테스트 완료
- [ ] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [ ] 코드에 주석/불필요한 로그 제거
- [ ] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
