### PR TITLE
Fix/90/retrospect

### DIFF
--- a/app/src/test/java/com/growit/app/retrospect/usecase/GetRetrospectUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/usecase/GetRetrospectUseCaseTest.java
@@ -39,8 +39,10 @@ class GetRetrospectUseCaseTest {
     // given
     Retrospect retrospect = RetrospectFixture.defaultRetrospect();
     Plan plan = PlanFixture.customPlan(retrospect.getPlanId(), null, null, null, null);
-    Goal goal = GoalFixture.customGoal(retrospect.getGoalId(), null, null, null, null, List.of(plan));
-    GetRetrospectCommand command = new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
+    Goal goal =
+        GoalFixture.customGoal(retrospect.getGoalId(), null, null, null, null, List.of(plan));
+    GetRetrospectCommand command =
+        new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
 
     RetrospectRepository retrospectRepository = mock(RetrospectRepository.class);
     GoalRepository goalRepository = mock(GoalRepository.class);
@@ -62,7 +64,8 @@ class GetRetrospectUseCaseTest {
   void givenNonexistentRetrospect_whenExecute_thenThrowNotFoundException() {
     // given
     Retrospect retrospect = RetrospectFixture.defaultRetrospect();
-    GetRetrospectCommand command = new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
+    GetRetrospectCommand command =
+        new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
 
     RetrospectRepository retrospectRepository = mock(RetrospectRepository.class);
     GoalRepository goalRepository = mock(GoalRepository.class);
@@ -73,15 +76,16 @@ class GetRetrospectUseCaseTest {
 
     // when & then
     assertThatThrownBy(() -> useCase.execute(command))
-      .isInstanceOf(NotFoundException.class)
-      .hasMessageContaining("회고를 찾을 수 없습니다.");
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("회고를 찾을 수 없습니다.");
   }
 
   @Test
   void givenNonexistentGoal_whenExecute_thenThrowNotFoundException() {
     // given
     Retrospect retrospect = RetrospectFixture.defaultRetrospect();
-    GetRetrospectCommand command = new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
+    GetRetrospectCommand command =
+        new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
 
     RetrospectRepository retrospectRepository = mock(RetrospectRepository.class);
     GoalRepository goalRepository = mock(GoalRepository.class);
@@ -93,8 +97,8 @@ class GetRetrospectUseCaseTest {
 
     // when & then
     assertThatThrownBy(() -> useCase.execute(command))
-      .isInstanceOf(NotFoundException.class)
-      .hasMessageContaining("목표가 존재하지 않습니다.");
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("목표가 존재하지 않습니다.");
   }
 
   @Test
@@ -102,7 +106,8 @@ class GetRetrospectUseCaseTest {
     // given
     Retrospect retrospect = RetrospectFixture.defaultRetrospect();
     Goal goal = GoalFixture.defaultGoal();
-    GetRetrospectCommand command = new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
+    GetRetrospectCommand command =
+        new GetRetrospectCommand(retrospect.getId(), retrospect.getUserId());
 
     RetrospectRepository retrospectRepository = mock(RetrospectRepository.class);
     GoalRepository goalRepository = mock(GoalRepository.class);
@@ -114,8 +119,7 @@ class GetRetrospectUseCaseTest {
 
     // when & then
     assertThatThrownBy(() -> useCase.execute(command))
-      .isInstanceOf(NotFoundException.class)
-      .hasMessageContaining("일치하는 Plan이 없습니다.");
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("일치하는 Plan이 없습니다.");
   }
 }
-


### PR DESCRIPTION
## 📌 PR 제목

> retrospect 함수 네이밍 변경

---

## ✅ PR 설명

- 기존 양식을 지키지 않은 함수명 (execute ~~~) 에서 given_when_then 형식으로 변경
- 관련 이슈: #90 

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
