### PR TITLE
사용자 탈퇴 기능 구현

### DIFF
--- a/app/src/main/java/com/growit/app/user/controller/UserController.java
+++ b/app/src/main/java/com/growit/app/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.growit.app.user.controller.mapper.RequestMapper;
 import com.growit.app.user.controller.mapper.ResponseMapper;
 import com.growit.app.user.domain.user.User;
 import com.growit.app.user.domain.user.dto.UserDto;
+import com.growit.app.user.usecase.DeleteUserUseCase;
 import com.growit.app.user.usecase.GetUserUseCase;
 import com.growit.app.user.usecase.LogoutUseCase;
 import com.growit.app.user.usecase.UpdateUserUseCase;
@@ -24,6 +25,7 @@ public class UserController {
   private final GetUserUseCase getUserUseCase;
   private final UpdateUserUseCase updateUserUseCase;
   private final LogoutUseCase logoutUseCase;
+  private final DeleteUserUseCase deleteUseCase;
   private final RequestMapper requestMapper;
   private final ResponseMapper responseMapper;
   private final MessageService messageService;
@@ -46,5 +48,11 @@ public class UserController {
   public ResponseEntity<ApiResponse<String>> logout(@AuthenticationPrincipal User user) {
     logoutUseCase.execute(user);
     return ResponseEntity.ok(ApiResponse.success(messageService.msg("success.user.logout")));
+  }
+
+  @DeleteMapping("/myprofile")
+  public ResponseEntity<ApiResponse<String>> deleteUser(@AuthenticationPrincipal User user) {
+    deleteUseCase.execute(user);
+    return ResponseEntity.ok(ApiResponse.success(messageService.msg("success.user.delete")));
   }
 }

--- a/app/src/main/java/com/growit/app/user/domain/user/User.java
+++ b/app/src/main/java/com/growit/app/user/domain/user/User.java
@@ -28,6 +28,8 @@ public class User {
 
   private RequiredConsent requiredConsent;
 
+  private boolean isDeleted;
+
   public static User from(SignUpCommand command) {
     return User.builder()
         .id(IDGenerator.generateId())
@@ -36,6 +38,7 @@ public class User {
         .name(command.name())
         .jobRoleId(command.jobRoleId())
         .careerYear(command.careerYear())
+        .isDeleted(false)
         .build();
   }
 
@@ -43,5 +46,9 @@ public class User {
     this.name = command.name();
     this.jobRoleId = command.jobRoleId();
     this.careerYear = command.careerYear();
+  }
+
+  public void deleted() {
+    this.isDeleted = true;
   }
 }

--- a/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/source/entity/UserEntity.java
+++ b/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/source/entity/UserEntity.java
@@ -39,7 +39,7 @@ public class UserEntity extends BaseEntity {
     this.name = user.getName();
     this.jobRoleId = user.getJobRoleId();
     this.careerYear = user.getCareerYear();
-    if(user.isDeleted()) {
+    if (user.isDeleted()) {
       this.setDeletedAt(LocalDateTime.now());
     }
   }

--- a/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/source/entity/UserEntity.java
+++ b/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/source/entity/UserEntity.java
@@ -4,6 +4,7 @@ import com.growit.app.common.entity.BaseEntity;
 import com.growit.app.user.domain.user.User;
 import com.growit.app.user.domain.user.vo.CareerYear;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -38,5 +39,8 @@ public class UserEntity extends BaseEntity {
     this.name = user.getName();
     this.jobRoleId = user.getJobRoleId();
     this.careerYear = user.getCareerYear();
+    if(user.isDeleted()) {
+      this.setDeletedAt(LocalDateTime.now());
+    }
   }
 }

--- a/app/src/main/java/com/growit/app/user/usecase/DeleteUserUseCase.java
+++ b/app/src/main/java/com/growit/app/user/usecase/DeleteUserUseCase.java
@@ -1,0 +1,26 @@
+package com.growit.app.user.usecase;
+
+import com.growit.app.user.domain.token.UserToken;
+import com.growit.app.user.domain.token.UserTokenRepository;
+import com.growit.app.user.domain.token.service.UserTokenQuery;
+import com.growit.app.user.domain.user.User;
+import com.growit.app.user.domain.user.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DeleteUserUseCase {
+  private final UserTokenQuery userTokenQuery;
+  private final UserTokenRepository userTokenRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void execute(User user) {
+    final UserToken userToken = userTokenQuery.getUserTokenByUserId(user.getId());
+    userTokenRepository.deleteUserToken(userToken);
+    user.deleted();
+    userRepository.saveUser(user);
+  }
+}

--- a/app/src/main/resources/messages.properties
+++ b/app/src/main/resources/messages.properties
@@ -80,3 +80,4 @@ error.retrospect-not-found=회고 정보가 존재하지 않습니다.
 
 success.user.update=사용자 정보를 업데이트 하였습니다.
 success.user.logout=로그아웃 되었습니다.
+success.user.delete=탈퇴 처리 되었습니다.

--- a/app/src/test/java/com/growit/app/user/controller/UserControllerTest.java
+++ b/app/src/test/java/com/growit/app/user/controller/UserControllerTest.java
@@ -21,6 +21,7 @@ import com.growit.app.user.controller.dto.request.UpdateUserRequest;
 import com.growit.app.user.controller.dto.response.UserResponse;
 import com.growit.app.user.controller.mapper.ResponseMapper;
 import com.growit.app.user.domain.user.User;
+import com.growit.app.user.usecase.DeleteUserUseCase;
 import com.growit.app.user.usecase.GetUserUseCase;
 import com.growit.app.user.usecase.LogoutUseCase;
 import com.growit.app.user.usecase.UpdateUserUseCase;
@@ -52,6 +53,7 @@ class UserControllerTest {
   @MockitoBean private GetUserUseCase getUserUseCase;
   @MockitoBean private UpdateUserUseCase updateUserUseCase;
   @MockitoBean private LogoutUseCase logoutUseCase;
+  @MockitoBean private DeleteUserUseCase deleteUserUseCase;
 
   @BeforeEach
   void setUp(

--- a/app/src/test/java/com/growit/app/user/controller/UserControllerTest.java
+++ b/app/src/test/java/com/growit/app/user/controller/UserControllerTest.java
@@ -163,4 +163,29 @@ class UserControllerTest {
                             fieldWithPath("data").type(STRING).description("로그아웃 성공 메세지"))
                         .build())));
   }
+
+  @Test
+  void deleteUser() throws Exception {
+    mockMvc
+        .perform(
+            delete("/users/myprofile")
+                .header("Authorization", "Bearer mock-jwt-token")
+                .contentType("application/json"))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "logout-user",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    new ResourceSnippetParametersBuilder()
+                        .tag("User")
+                        .summary("사용자 탈퇴")
+                        .requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION)
+                                .attributes(key("type").value("String"))
+                                .description("JWT (Your Token)"))
+                        .responseFields(fieldWithPath("data").type(STRING).description("탈퇴 성공 메세지"))
+                        .build())));
+  }
 }

--- a/app/src/test/java/com/growit/app/user/usecase/DeleteUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/user/usecase/DeleteUseCaseTest.java
@@ -1,0 +1,35 @@
+package com.growit.app.user.usecase;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.growit.app.fake.user.UserFixture;
+import com.growit.app.user.domain.token.UserTokenRepository;
+import com.growit.app.user.domain.token.service.UserTokenQuery;
+import com.growit.app.user.domain.token.service.exception.InvalidTokenException;
+import com.growit.app.user.domain.user.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteUseCaseTest {
+
+  @Mock private UserTokenRepository userTokenRepository;
+
+  @Mock private UserTokenQuery userTokenQuery;
+
+  @InjectMocks private DeleteUserUseCase deleteUserUseCase;
+
+  @Test
+  void givenUserTokenNotExists_whenExecute_thenThrowsInvalidUserTokenException() {
+    // given
+    User user = UserFixture.defaultUser();
+    when(userTokenQuery.getUserTokenByUserId(user.getId())).thenThrow(InvalidTokenException.class);
+
+    // when & then
+    assertThrows(InvalidTokenException.class, () -> deleteUserUseCase.execute(user));
+  }
+}

--- a/app/src/test/java/com/growit/app/user/usecase/UpdateUserUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/user/usecase/UpdateUserUseCaseTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 
 import com.growit.app.common.exception.BadRequestException;
 import com.growit.app.fake.user.UserFixture;
-import com.growit.app.resource.domain.jobrole.service.JobRoleQuery;
 import com.growit.app.resource.domain.jobrole.service.JobRoleValidator;
 import com.growit.app.user.domain.user.User;
 import com.growit.app.user.domain.user.UserRepository;


### PR DESCRIPTION
## 📌 PR 제목

> feat 사용자 탈퇴 기능 구현

---

## ✅ PR 설명

- userToken 조회 및 삭제
- 사용자 deleted 함수 호출 후 deletedAt 적용

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
