### PR TITLE
fix(user): userId 존재여부에 userToken 저장 진행

### DIFF
--- a/app/src/main/java/com/growit/app/user/domain/token/service/UserTokenSaver.java
+++ b/app/src/main/java/com/growit/app/user/domain/token/service/UserTokenSaver.java
@@ -1,0 +1,7 @@
+package com.growit.app.user.domain.token.service;
+
+import com.growit.app.user.domain.token.vo.Token;
+
+public interface UserTokenSaver {
+  void saveUserToken(String userId, Token token);
+}

--- a/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/UserDBMapper.java
+++ b/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/UserDBMapper.java
@@ -27,6 +27,7 @@ public class UserDBMapper {
         .name(entity.getName())
         .jobRoleId(entity.getJobRoleId())
         .careerYear(entity.getCareerYear())
+        .isDeleted(entity.getDeletedAt() != null)
         .build();
   }
 }

--- a/app/src/main/java/com/growit/app/user/usecase/SignInUseCase.java
+++ b/app/src/main/java/com/growit/app/user/usecase/SignInUseCase.java
@@ -4,9 +4,8 @@ import static com.growit.app.common.util.message.ErrorCode.USER_SIGN_IN_FAILED;
 
 import com.growit.app.common.exception.BaseException;
 import com.growit.app.common.exception.NotFoundException;
-import com.growit.app.user.domain.token.UserToken;
-import com.growit.app.user.domain.token.UserTokenRepository;
 import com.growit.app.user.domain.token.service.TokenGenerator;
+import com.growit.app.user.domain.token.service.UserTokenSaver;
 import com.growit.app.user.domain.token.vo.Token;
 import com.growit.app.user.domain.user.User;
 import com.growit.app.user.domain.user.dto.SignInCommand;
@@ -20,7 +19,7 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class SignInUseCase {
   private final UserQuery userQuery;
-  private final UserTokenRepository userTokenRepository;
+  private final UserTokenSaver userTokenSaver;
   private final PasswordEncoder passwordEncoder;
   private final TokenGenerator tokenGenerator;
 
@@ -32,7 +31,7 @@ public class SignInUseCase {
     if (!isCorrectPassword) throw new NotFoundException(USER_SIGN_IN_FAILED.getCode());
 
     final Token token = tokenGenerator.createToken(user);
-    userTokenRepository.saveUserToken(UserToken.from(user.getId(), token.refreshToken()));
+    userTokenSaver.saveUserToken(user.getId(), token);
 
     return token;
   }

--- a/app/src/test/java/com/growit/app/user/usecase/SignInUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/user/usecase/SignInUseCaseTest.java
@@ -5,8 +5,8 @@ import static org.mockito.Mockito.*;
 
 import com.growit.app.common.exception.NotFoundException;
 import com.growit.app.fake.user.UserFixture;
-import com.growit.app.user.domain.token.UserTokenRepository;
 import com.growit.app.user.domain.token.service.TokenGenerator;
+import com.growit.app.user.domain.token.service.UserTokenSaver;
 import com.growit.app.user.domain.token.vo.Token;
 import com.growit.app.user.domain.user.User;
 import com.growit.app.user.domain.user.dto.SignInCommand;
@@ -27,7 +27,7 @@ class SignInUseCaseTest {
 
   @Mock private TokenGenerator tokenGenerator;
 
-  @Mock private UserTokenRepository userTokenRepository;
+  @Mock private UserTokenSaver userTokenSaver;
 
   @InjectMocks private SignInUseCase signInUseCase;
 


### PR DESCRIPTION
userId 당 하나의 userToken으로 정의

Closes #148

## 📌 PR 제목

> fix: userId 당 토큰 관리 한개로 변경

---

## ✅ PR 설명

- 토큰 관리되는 user는 한명으로 제한합니다. 이를 통해 동시접속 후 이전 사용자는 로그아웃 처리되게됩니다. 
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
