### PR TITLE
fix(goalretrospect): 목표 회고 생성시 이미 존재 여부 확인 로직 추가

### DIFF
--- a/app/src/main/java/com/growit/app/common/util/message/ErrorCode.java
+++ b/app/src/main/java/com/growit/app/common/util/message/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
       "error.retrospect-already-exists-by-plan"), // "해당 주간 계획에 대한 회고가 이미 존재합니다."
   TODO_IS_EXIST("error.todo.is-exist"), // "ToDo가 존재합니다."
   GOAL_RETROSPECT_GOAL_NOT_COMPLETED("error.goal-retrospect-not-completed"), // "목표가 완료되지 않았습니다."
-
+  GOAL_RETROSPECT_ALREADY_EXISTS("error.goal-retrospect-already_exists"), // "이미 회고가 존재합니다"
   RETROSPECT_NOT_FOUND("error.retrospect-not-found"); // "회고 정보가 존재하지 않습니다."
   private final String code;
 

--- a/app/src/main/java/com/growit/app/retrospect/domain/goalretrospect/service/GoalRetrospectQuery.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/goalretrospect/service/GoalRetrospectQuery.java
@@ -5,4 +5,6 @@ import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospect;
 
 public interface GoalRetrospectQuery {
   GoalRetrospect getMyGoalRetrospect(String id, String userId) throws NotFoundException;
+
+  boolean isExistsByGoalId(String goalId);
 }

--- a/app/src/main/java/com/growit/app/retrospect/domain/goalretrospect/service/GoalRetrospectService.java
+++ b/app/src/main/java/com/growit/app/retrospect/domain/goalretrospect/service/GoalRetrospectService.java
@@ -18,4 +18,16 @@ public class GoalRetrospectService implements GoalRetrospectQuery {
         .findById(id)
         .orElseThrow(() -> new NotFoundException(ErrorCode.RETROSPECT_NOT_FOUND.getCode()));
   }
+
+  @Override
+  public boolean isExistsByGoalId(String goalId) {
+    try {
+      goalRetrospectRepository
+          .findByGoalId(goalId)
+          .orElseThrow(() -> new NotFoundException(ErrorCode.RETROSPECT_NOT_FOUND.getCode()));
+      return true;
+    } catch (NotFoundException e) {
+      return false;
+    }
+  }
 }

--- a/app/src/main/java/com/growit/app/retrospect/usecase/goalretrospect/CreateGoalRetrospectUseCase.java
+++ b/app/src/main/java/com/growit/app/retrospect/usecase/goalretrospect/CreateGoalRetrospectUseCase.java
@@ -8,6 +8,7 @@ import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospect;
 import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospectRepository;
 import com.growit.app.retrospect.domain.goalretrospect.dto.CreateGoalRetrospectCommand;
 import com.growit.app.retrospect.domain.goalretrospect.service.AIAnalysis;
+import com.growit.app.retrospect.domain.goalretrospect.service.GoalRetrospectQuery;
 import com.growit.app.retrospect.domain.goalretrospect.vo.Analysis;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import com.growit.app.retrospect.domain.retrospect.service.RetrospectQuery;
@@ -27,10 +28,14 @@ public class CreateGoalRetrospectUseCase {
   private final ToDoQuery toDoQuery;
   private final AIAnalysis aiAnalysis;
   private final GoalRetrospectRepository goalRetrospectRepository;
+  private final GoalRetrospectQuery goalRetrospectQuery;
   private final RetrospectQuery retrospectQuery;
 
   @Transactional
   public String execute(CreateGoalRetrospectCommand command) {
+    if (goalRetrospectQuery.isExistsByGoalId(command.goalId())) {
+      throw new BadRequestException("이미 목표 회고가 존재합니다"); // message unicode 변경으로 인한 메세지 지정
+    }
     final Goal goal = goalQuery.getMyGoal(command.goalId(), command.userId());
     if (!goal.finished()) {
       throw new BadRequestException(ErrorCode.GOAL_RETROSPECT_GOAL_NOT_COMPLETED.getCode());

--- a/app/src/main/resources/static/docs/swagger-spec.js
+++ b/app/src/main/resources/static/docs/swagger-spec.js
@@ -140,7 +140,7 @@ window.swaggerSpec={
                 },
                 "examples" : {
                   "get-goal-retrospects-by-year" : {
-                    "value" : "{\n  \"data\" : [ {\n    \"goal\" : {\n      \"id\" : \"goal-1\",\n      \"name\" : \"테스트 목표\",\n      \"duration\" : {\n        \"startDate\" : \"2025-08-25\",\n        \"endDate\" : \"2025-08-31\"\n      }\n    },\n    \"goalRetrospect\" : {\n      \"id\" : \"H-OfiH8pOxXa4VqmktFbr\",\n      \"isCompleted\" : true\n    }\n  } ]\n}"
+                    "value" : "{\n  \"data\" : [ {\n    \"goal\" : {\n      \"id\" : \"goal-1\",\n      \"name\" : \"테스트 목표\",\n      \"duration\" : {\n        \"startDate\" : \"2025-08-25\",\n        \"endDate\" : \"2025-08-31\"\n      }\n    },\n    \"goalRetrospect\" : {\n      \"id\" : \"_ST4yR_2KnxeHsfccLMSa\",\n      \"isCompleted\" : true\n    }\n  } ]\n}"
                   }
                 }
               }
@@ -211,7 +211,7 @@ window.swaggerSpec={
                 },
                 "examples" : {
                   "get-goal-retrospect" : {
-                    "value" : "{\n  \"data\" : {\n    \"id\" : \"CwCg4VGp3rJjLEjf16XO_\",\n    \"goalId\" : \"goalId\",\n    \"todoCompletedRate\" : 25,\n    \"analysis\" : {\n      \"summary\" : \"GROWIT MVP 개발과 서비스 기획을 병행하며 4주 목표를 달성\",\n      \"advice\" : \"모든 활동이 한 가지 핵심 가치에 연결되도록 중심축을 명확히 해보라냥!\"\n    },\n    \"content\" : \"이번 달 나는 '나만의 의미 있는 일'을 찾기 위해 다양한 프로젝트와 리서치에 몰입했다...\"\n  }\n}"
+                    "value" : "{\n  \"data\" : {\n    \"id\" : \"lUVa8rp-a_9IjFwKnv3Dj\",\n    \"goalId\" : \"goalId\",\n    \"todoCompletedRate\" : 25,\n    \"analysis\" : {\n      \"summary\" : \"GROWIT MVP 개발과 서비스 기획을 병행하며 4주 목표를 달성\",\n      \"advice\" : \"모든 활동이 한 가지 핵심 가치에 연결되도록 중심축을 명확히 해보라냥!\"\n    },\n    \"content\" : \"이번 달 나는 '나만의 의미 있는 일'을 찾기 위해 다양한 프로젝트와 리서치에 몰입했다...\"\n  }\n}"
                   }
                 }
               }
@@ -296,7 +296,7 @@ window.swaggerSpec={
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/goals-id70548334"
+                "$ref" : "#/components/schemas/goals70548334"
               },
               "examples" : {
                 "create-goal" : {
@@ -316,7 +316,7 @@ window.swaggerSpec={
                 },
                 "examples" : {
                   "create-goal" : {
-                    "value" : "{\n  \"data\" : {\n    \"id\" : \"zSeEWWLERWRVYVFyWgoTi\"\n  }\n}"
+                    "value" : "{\n  \"data\" : {\n    \"id\" : \"dXgvS_X71JKGnaq5LeO_z\"\n  }\n}"
                   }
                 }
               }
@@ -376,7 +376,7 @@ window.swaggerSpec={
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/goals-id70548334"
+                "$ref" : "#/components/schemas/goals70548334"
               },
               "examples" : {
                 "update-goal" : {
@@ -768,10 +768,10 @@ window.swaggerSpec={
                 },
                 "examples" : {
                   "get-today-mission" : {
-                    "value" : "{\n  \"data\" : [ {\n    \"id\" : \"id\",\n    \"goalId\" : \"goalId\",\n    \"planId\" : \"planId\",\n    \"content\" : \"테스트 할 일입니다.\",\n    \"date\" : \"2025-08-25\",\n    \"isCompleted\" : false\n  }, {\n    \"id\" : \"id2\",\n    \"goalId\" : \"goalId\",\n    \"planId\" : \"planId\",\n    \"content\" : \"테스트 할 일입니다.\",\n    \"date\" : \"2025-08-25\",\n    \"isCompleted\" : false\n  } ]\n}"
+                    "value" : "{\n  \"data\" : [ {\n    \"id\" : \"id\",\n    \"goalId\" : \"goalId\",\n    \"planId\" : \"planId\",\n    \"content\" : \"테스트 할 일입니다.\",\n    \"date\" : \"2025-08-29\",\n    \"isCompleted\" : false\n  }, {\n    \"id\" : \"id2\",\n    \"goalId\" : \"goalId\",\n    \"planId\" : \"planId\",\n    \"content\" : \"테스트 할 일입니다.\",\n    \"date\" : \"2025-08-29\",\n    \"isCompleted\" : false\n  } ]\n}"
                   },
                   "get-weekly-plan" : {
-                    "value" : "{\n  \"data\" : {\n    \"MONDAY\" : [ {\n      \"id\" : \"todoId\",\n      \"goalId\" : \"goal-123\",\n      \"planId\" : \"plan-456\",\n      \"date\" : \"2025-08-25\",\n      \"content\" : \"목표\",\n      \"isCompleted\" : true\n    } ],\n    \"TUESDAY\" : [ ],\n    \"WEDNESDAY\" : [ ],\n    \"THURSDAY\" : [ ],\n    \"FRIDAY\" : [ ],\n    \"SATURDAY\" : [ ],\n    \"SUNDAY\" : [ ]\n  }\n}"
+                    "value" : "{\n  \"data\" : {\n    \"MONDAY\" : [ {\n      \"id\" : \"todoId\",\n      \"goalId\" : \"goal-123\",\n      \"planId\" : \"plan-456\",\n      \"date\" : \"2025-08-29\",\n      \"content\" : \"목표\",\n      \"isCompleted\" : true\n    } ],\n    \"TUESDAY\" : [ ],\n    \"WEDNESDAY\" : [ ],\n    \"THURSDAY\" : [ ],\n    \"FRIDAY\" : [ ],\n    \"SATURDAY\" : [ ],\n    \"SUNDAY\" : [ ]\n  }\n}"
                   }
                 }
               }
@@ -792,7 +792,7 @@ window.swaggerSpec={
               },
               "examples" : {
                 "create-todo" : {
-                  "value" : "{\n  \"goalId\" : \"goal-1\",\n  \"date\" : \"2025-08-25\",\n  \"content\" : \"할 일 예시 내용입니다.\"\n}"
+                  "value" : "{\n  \"goalId\" : \"goal-1\",\n  \"date\" : \"2025-08-29\",\n  \"content\" : \"할 일 예시 내용입니다.\"\n}"
                 }
               }
             }
@@ -842,7 +842,7 @@ window.swaggerSpec={
                 },
                 "examples" : {
                   "get-todo" : {
-                    "value" : "{\n  \"data\" : {\n    \"id\" : \"todo-1\",\n    \"goalId\" : \"goal-1\",\n    \"planId\" : \"plan-1\",\n    \"content\" : \"테스트 할 일입니다.\",\n    \"date\" : \"2025-08-25\",\n    \"isCompleted\" : false\n  }\n}"
+                    "value" : "{\n  \"data\" : {\n    \"id\" : \"todo-1\",\n    \"goalId\" : \"goal-1\",\n    \"planId\" : \"plan-1\",\n    \"content\" : \"테스트 할 일입니다.\",\n    \"date\" : \"2025-08-29\",\n    \"isCompleted\" : false\n  }\n}"
                   }
                 }
               }
@@ -872,7 +872,7 @@ window.swaggerSpec={
               },
               "examples" : {
                 "update-todo" : {
-                  "value" : "{\n  \"date\" : \"2025-08-25\",\n  \"content\" : \"수정된 내용\"\n}"
+                  "value" : "{\n  \"date\" : \"2025-08-29\",\n  \"content\" : \"수정된 내용\"\n}"
                 }
               }
             }
@@ -1487,6 +1487,20 @@ window.swaggerSpec={
           }
         }
       },
+      "goals574842772" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "string",
+                "description" : "목표 ID"
+              }
+            }
+          }
+        }
+      },
       "todos1427672143" : {
         "type" : "object",
         "properties" : {
@@ -1648,20 +1662,6 @@ window.swaggerSpec={
           }
         }
       },
-      "goals574842772" : {
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "object",
-            "properties" : {
-              "id" : {
-                "type" : "string",
-                "description" : "목표 ID"
-              }
-            }
-          }
-        }
-      },
       "goal-retrospects-1650437255" : {
         "type" : "object",
         "properties" : {
@@ -1676,7 +1676,7 @@ window.swaggerSpec={
           }
         }
       },
-      "goals-id70548334" : {
+      "goals70548334" : {
         "type" : "object",
         "properties" : {
           "duration" : {

--- a/app/src/test/java/com/growit/app/retrospect/usecase/CreateGoalRetrospectUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/usecase/CreateGoalRetrospectUseCaseTest.java
@@ -13,6 +13,7 @@ import com.growit.app.goal.domain.goal.vo.GoalUpdateStatus;
 import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospectRepository;
 import com.growit.app.retrospect.domain.goalretrospect.dto.CreateGoalRetrospectCommand;
 import com.growit.app.retrospect.domain.goalretrospect.service.AIAnalysis;
+import com.growit.app.retrospect.domain.goalretrospect.service.GoalRetrospectQuery;
 import com.growit.app.retrospect.domain.goalretrospect.vo.Analysis;
 import com.growit.app.retrospect.domain.retrospect.service.RetrospectQuery;
 import com.growit.app.retrospect.usecase.goalretrospect.CreateGoalRetrospectUseCase;
@@ -30,6 +31,7 @@ class CreateGoalRetrospectUseCaseTest {
   @Mock private ToDoQuery toDoQuery;
   @Mock private AIAnalysis aiAnalysis;
   @Mock private GoalRetrospectRepository goalRetrospectRepository;
+  @Mock private GoalRetrospectQuery goalRetrospectQuery;
   @Mock private RetrospectQuery retrospectQuery;
 
   @InjectMocks private CreateGoalRetrospectUseCase useCase;
@@ -39,7 +41,7 @@ class CreateGoalRetrospectUseCaseTest {
     // given
     Goal goal = GoalFixture.defaultGoal();
     goal.updateByGoalUpdateStatus(GoalUpdateStatus.ENDED);
-
+    when(goalRetrospectQuery.isExistsByGoalId(goal.getId())).thenReturn(false);
     when(goalQuery.getMyGoal(goal.getId(), goal.getUserId())).thenReturn(goal);
     CreateGoalRetrospectCommand command =
         new CreateGoalRetrospectCommand(goal.getUserId(), goal.getId());
@@ -55,7 +57,7 @@ class CreateGoalRetrospectUseCaseTest {
     // given
     Goal goal = GoalFixture.defaultGoal();
     goal.updateByGoalUpdateStatus(GoalUpdateStatus.UPDATABLE);
-
+    when(goalRetrospectQuery.isExistsByGoalId(goal.getId())).thenReturn(false);
     when(goalQuery.getMyGoal(goal.getId(), goal.getUserId())).thenReturn(goal);
     CreateGoalRetrospectCommand command =
         new CreateGoalRetrospectCommand(goal.getUserId(), goal.getId());


### PR DESCRIPTION
Closes #218

## 📌 PR 제목

> bug: 목표 회고 조회시 이미 존재 여부 로직을 추가하였습니다. 

---

## ✅ PR 설명

- goalId unique 제약으로 인한 에러 발생
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [x ] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
