### PR TITLE
feat(224/invitation): 초대장 생성 API 및 디스코드 알림 기능 추가

### DIFF
--- a/app/src/main/java/com/growit/app/common/config/SecurityConfig.java
+++ b/app/src/main/java/com/growit/app/common/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         "/auth/**",
                         "/h2-console/**",
                         "/resource/**",
+                        "/externals/**",
                         "/docs/**",
                         "/static/**")
                     .permitAll()

--- a/app/src/main/java/com/growit/app/common/config/jwt/JwtFilter.java
+++ b/app/src/main/java/com/growit/app/common/config/jwt/JwtFilter.java
@@ -36,6 +36,7 @@ public class JwtFilter extends OncePerRequestFilter {
           || uri.startsWith("/h2-console")
           || uri.startsWith("/swagger-ui")
           || uri.startsWith("/static")
+          || uri.startsWith("/externals")
           || uri.startsWith("/resource")) {
         filterChain.doFilter(request, response);
         return;

--- a/app/src/main/java/com/growit/app/resource/controller/ExternalController.java
+++ b/app/src/main/java/com/growit/app/resource/controller/ExternalController.java
@@ -3,6 +3,7 @@ package com.growit.app.resource.controller;
 import com.growit.app.common.response.ApiResponse;
 import com.growit.app.common.util.message.MessageService;
 import com.growit.app.resource.controller.dto.request.InvitationRequest;
+import com.growit.app.resource.controller.dto.response.InvitationResponse;
 import com.growit.app.resource.usecase.CreateInvitationUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +18,10 @@ public class ExternalController {
   private final MessageService messageService;
 
   @PostMapping("/invitations")
-  public ResponseEntity<ApiResponse<String>> createInvitation(
+  public ResponseEntity<ApiResponse<InvitationResponse>> createInvitation(
       @Valid @RequestBody InvitationRequest request) {
     createInvitationUseCase.execute(request.phone());
-    return ResponseEntity.ok(ApiResponse.success(messageService.msg("success.invitation.sent")));
+    String message = messageService.msg("success.invitation.sent");
+    return ResponseEntity.ok(ApiResponse.success(InvitationResponse.of(message)));
   }
 }

--- a/app/src/main/java/com/growit/app/resource/controller/ExternalController.java
+++ b/app/src/main/java/com/growit/app/resource/controller/ExternalController.java
@@ -1,0 +1,25 @@
+package com.growit.app.resource.controller;
+
+import com.growit.app.common.response.ApiResponse;
+import com.growit.app.common.util.message.MessageService;
+import com.growit.app.resource.controller.dto.request.InvitationRequest;
+import com.growit.app.resource.usecase.CreateInvitationUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/externals")
+@RequiredArgsConstructor
+public class ExternalController {
+  private final CreateInvitationUseCase createInvitationUseCase;
+  private final MessageService messageService;
+
+  @PostMapping("/invitations")
+  public ResponseEntity<ApiResponse<String>> createInvitation(
+      @Valid @RequestBody InvitationRequest request) {
+    createInvitationUseCase.execute(request.phone());
+    return ResponseEntity.ok(ApiResponse.success(messageService.msg("success.invitation.sent")));
+  }
+}

--- a/app/src/main/java/com/growit/app/resource/controller/ResourceController.java
+++ b/app/src/main/java/com/growit/app/resource/controller/ResourceController.java
@@ -3,6 +3,7 @@ package com.growit.app.resource.controller;
 import com.growit.app.common.response.ApiResponse;
 import com.growit.app.common.util.message.MessageService;
 import com.growit.app.resource.controller.dto.request.InvitationRequest;
+import com.growit.app.resource.controller.dto.response.InvitationResponse;
 import com.growit.app.resource.controller.dto.response.SayingResponse;
 import com.growit.app.resource.controller.mapper.ResourceResponseMapper;
 import com.growit.app.resource.domain.jobrole.JobRole;
@@ -46,9 +47,10 @@ public class ResourceController {
   }
 
   @PostMapping("/invitations")
-  public ResponseEntity<ApiResponse<String>> createInvitation(
+  public ResponseEntity<ApiResponse<InvitationResponse>> createInvitation(
       @Valid @RequestBody InvitationRequest request) {
     createInvitationUseCase.execute(request.phone());
-    return ResponseEntity.ok(ApiResponse.success(messageService.msg("success.invitation.sent")));
+    String message = messageService.msg("success.invitation.sent");
+    return ResponseEntity.ok(ApiResponse.success(InvitationResponse.of(message)));
   }
 }

--- a/app/src/main/java/com/growit/app/resource/controller/ResourceController.java
+++ b/app/src/main/java/com/growit/app/resource/controller/ResourceController.java
@@ -1,17 +1,23 @@
 package com.growit.app.resource.controller;
 
 import com.growit.app.common.response.ApiResponse;
+import com.growit.app.common.util.message.MessageService;
+import com.growit.app.resource.controller.dto.request.InvitationRequest;
 import com.growit.app.resource.controller.dto.response.SayingResponse;
 import com.growit.app.resource.controller.mapper.ResourceResponseMapper;
 import com.growit.app.resource.domain.jobrole.JobRole;
 import com.growit.app.resource.domain.jobrole.repository.JobRoleRepository;
 import com.growit.app.resource.domain.saying.Saying;
+import com.growit.app.resource.usecase.CreateInvitationUseCase;
 import com.growit.app.resource.usecase.GetSayingUseCase;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +28,8 @@ public class ResourceController {
   private final JobRoleRepository jobRoleRepository;
   private final GetSayingUseCase getSayingUseCase;
   private final ResourceResponseMapper responseMapper;
+  private final CreateInvitationUseCase createInvitationUseCase;
+  private final MessageService messageService;
 
   @GetMapping("/jobroles")
   public ResponseEntity<ApiResponse<Map<String, Object>>> getAllJobRoles() {
@@ -35,5 +43,12 @@ public class ResourceController {
     Saying saying = getSayingUseCase.execute();
 
     return ResponseEntity.ok(ApiResponse.success(responseMapper.toSayingResponse(saying)));
+  }
+
+  @PostMapping("/invitations")
+  public ResponseEntity<ApiResponse<String>> createInvitation(
+      @Valid @RequestBody InvitationRequest request) {
+    createInvitationUseCase.execute(request.phone());
+    return ResponseEntity.ok(ApiResponse.success(messageService.msg("success.invitation.sent")));
   }
 }

--- a/app/src/main/java/com/growit/app/resource/controller/dto/request/InvitationRequest.java
+++ b/app/src/main/java/com/growit/app/resource/controller/dto/request/InvitationRequest.java
@@ -1,0 +1,9 @@
+package com.growit.app.resource.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record InvitationRequest(
+    @NotBlank(message = "validation.invitation.phone.required")
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "validation.invitation.phone.pattern")
+        String phone) {}

--- a/app/src/main/java/com/growit/app/resource/controller/dto/request/InvitationRequest.java
+++ b/app/src/main/java/com/growit/app/resource/controller/dto/request/InvitationRequest.java
@@ -1,8 +1,6 @@
 package com.growit.app.resource.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record InvitationRequest(
-    @NotBlank(message = "validation.invitation.phone.required")
-        String phone) {}
+    @NotBlank(message = "validation.invitation.phone.required") String phone) {}

--- a/app/src/main/java/com/growit/app/resource/controller/dto/request/InvitationRequest.java
+++ b/app/src/main/java/com/growit/app/resource/controller/dto/request/InvitationRequest.java
@@ -5,5 +5,4 @@ import jakarta.validation.constraints.Pattern;
 
 public record InvitationRequest(
     @NotBlank(message = "validation.invitation.phone.required")
-        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "validation.invitation.phone.pattern")
         String phone) {}

--- a/app/src/main/java/com/growit/app/resource/controller/dto/response/InvitationResponse.java
+++ b/app/src/main/java/com/growit/app/resource/controller/dto/response/InvitationResponse.java
@@ -1,0 +1,18 @@
+package com.growit.app.resource.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InvitationResponse {
+  private String message;
+
+  public static InvitationResponse of(String message) {
+    return InvitationResponse.builder().message(message).build();
+  }
+}

--- a/app/src/main/java/com/growit/app/resource/infrastructure/discord/DiscordWebhookClient.java
+++ b/app/src/main/java/com/growit/app/resource/infrastructure/discord/DiscordWebhookClient.java
@@ -1,0 +1,62 @@
+package com.growit.app.resource.infrastructure.discord;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.growit.app.resource.infrastructure.discord.dto.DiscordEmbed;
+import com.growit.app.resource.infrastructure.discord.dto.DiscordField;
+import com.growit.app.resource.infrastructure.discord.dto.DiscordWebhookRequest;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordWebhookClient {
+
+  private final RestTemplate restTemplate;
+  private final ObjectMapper objectMapper;
+
+  private static final String DISCORD_WEBHOOK_URL =
+      "https://discord.com/api/webhooks/1416585254415765535/MAxIHEiDGl_zrGqbzaYjzXhymNrZdpPUJPIiQ0UArGM0_Fps4KqoufIcgqt3I_ikZmjd";
+
+  public void sendInvitation(String phone) {
+    try {
+      String message = String.format("새로운 초대장 요청이 있습니다.%n전화번호: %s", phone);
+
+      DiscordField phoneField = DiscordField.of("전화번호", phone, true);
+      DiscordEmbed embed =
+          DiscordEmbed.of(
+              "📱 초대장 요청", "새로운 사용자가 초대장을 요청했습니다.", Instant.now().toString(), List.of(phoneField));
+
+      DiscordWebhookRequest payload = DiscordWebhookRequest.of(message, List.of(embed));
+
+      String json = objectMapper.writeValueAsString(payload);
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+
+      HttpEntity<String> request = new HttpEntity<>(json, headers);
+      ResponseEntity<String> response =
+          restTemplate.postForEntity(DISCORD_WEBHOOK_URL, request, String.class);
+
+      if (response.getStatusCode().is2xxSuccessful()) {
+        log.info("Discord webhook sent successfully for phone: {}", phone);
+      } else {
+        log.error(
+            "Failed to send Discord webhook. Status: {}, Response: {}",
+            response.getStatusCode(),
+            response.getBody());
+      }
+
+    } catch (Exception e) {
+      log.error("Error sending Discord webhook for phone: {}", phone, e);
+    }
+  }
+}

--- a/app/src/main/java/com/growit/app/resource/infrastructure/discord/dto/DiscordEmbed.java
+++ b/app/src/main/java/com/growit/app/resource/infrastructure/discord/dto/DiscordEmbed.java
@@ -1,0 +1,11 @@
+package com.growit.app.resource.infrastructure.discord.dto;
+
+import java.util.List;
+
+public record DiscordEmbed(
+    String title, String description, String timestamp, List<DiscordField> fields) {
+  public static DiscordEmbed of(
+      String title, String description, String timestamp, List<DiscordField> fields) {
+    return new DiscordEmbed(title, description, timestamp, fields);
+  }
+}

--- a/app/src/main/java/com/growit/app/resource/infrastructure/discord/dto/DiscordField.java
+++ b/app/src/main/java/com/growit/app/resource/infrastructure/discord/dto/DiscordField.java
@@ -1,0 +1,11 @@
+package com.growit.app.resource.infrastructure.discord.dto;
+
+public record DiscordField(String name, String value, boolean inline) {
+  public static DiscordField of(String name, String value, boolean inline) {
+    return new DiscordField(name, value, inline);
+  }
+
+  public static DiscordField of(String name, String value) {
+    return new DiscordField(name, value, false);
+  }
+}

--- a/app/src/main/java/com/growit/app/resource/infrastructure/discord/dto/DiscordWebhookRequest.java
+++ b/app/src/main/java/com/growit/app/resource/infrastructure/discord/dto/DiscordWebhookRequest.java
@@ -1,0 +1,9 @@
+package com.growit.app.resource.infrastructure.discord.dto;
+
+import java.util.List;
+
+public record DiscordWebhookRequest(String content, List<DiscordEmbed> embeds) {
+  public static DiscordWebhookRequest of(String content, List<DiscordEmbed> embeds) {
+    return new DiscordWebhookRequest(content, embeds);
+  }
+}

--- a/app/src/main/java/com/growit/app/resource/usecase/CreateInvitationUseCase.java
+++ b/app/src/main/java/com/growit/app/resource/usecase/CreateInvitationUseCase.java
@@ -1,0 +1,15 @@
+package com.growit.app.resource.usecase;
+
+import com.growit.app.resource.infrastructure.discord.DiscordWebhookClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateInvitationUseCase {
+  private final DiscordWebhookClient discordWebhookClient;
+
+  public void execute(String phone) {
+    discordWebhookClient.sendInvitation(phone);
+  }
+}

--- a/app/src/main/resources/messages.properties
+++ b/app/src/main/resources/messages.properties
@@ -103,3 +103,8 @@ success.plan.content.update=주간 목표 수정이 완료되었습니다.
 success.goal.delete=삭제 완료되었습니다.
 success.mission.created=미션 생성이 완료되었습니다.
 success.mission.finished=미션을 완료하였습니다.
+
+# ✅ Invitation Messages
+success.invitation.sent=초대장 요청이 전송되었습니다.
+validation.invitation.phone.required=전화번호는 필수입니다.
+validation.invitation.phone.pattern=전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)

--- a/app/src/test/java/com/growit/app/fake/resource/InvitationFixture.java
+++ b/app/src/test/java/com/growit/app/fake/resource/InvitationFixture.java
@@ -6,10 +6,6 @@ public class InvitationFixture {
     return new InvitationRequestBodyBuilder().build();
   }
 
-  public static String invalidPhoneFormatRequestBody() {
-    return new InvitationRequestBodyBuilder().phone("01012345678").build();
-  }
-
   public static String customInvitationRequestBody(String phone) {
     return new InvitationRequestBodyBuilder()
         .phone(phone != null ? phone : "010-1234-5678")

--- a/app/src/test/java/com/growit/app/fake/resource/InvitationFixture.java
+++ b/app/src/test/java/com/growit/app/fake/resource/InvitationFixture.java
@@ -1,0 +1,37 @@
+package com.growit.app.fake.resource;
+
+public class InvitationFixture {
+
+  public static String validInvitationRequestBody() {
+    return new InvitationRequestBodyBuilder().build();
+  }
+
+  public static String invalidPhoneFormatRequestBody() {
+    return new InvitationRequestBodyBuilder().phone("01012345678").build();
+  }
+
+  public static String customInvitationRequestBody(String phone) {
+    return new InvitationRequestBodyBuilder()
+        .phone(phone != null ? phone : "010-1234-5678")
+        .build();
+  }
+}
+
+class InvitationRequestBodyBuilder {
+  private String phone = "010-1234-5678";
+
+  public InvitationRequestBodyBuilder phone(String phone) {
+    this.phone = phone;
+    return this;
+  }
+
+  public String build() {
+    return String.format(
+        """
+        {
+          "phone": "%s"
+        }
+        """,
+        phone);
+  }
+}

--- a/app/src/test/java/com/growit/app/resource/controller/ExternalControllerTest.java
+++ b/app/src/test/java/com/growit/app/resource/controller/ExternalControllerTest.java
@@ -3,21 +3,14 @@ package com.growit.app.resource.controller;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.SimpleType.STRING;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
 import com.growit.app.fake.resource.InvitationFixture;
-import com.growit.app.fake.resource.JobRoleFixture;
-import com.growit.app.fake.resource.SayingFixture;
-import com.growit.app.resource.domain.jobrole.repository.JobRoleRepository;
 import com.growit.app.resource.usecase.CreateInvitationUseCase;
-import com.growit.app.resource.usecase.GetSayingUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,12 +27,10 @@ import org.springframework.web.context.WebApplicationContext;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @SpringBootTest
-class ResourceControllerTest {
+class ExternalControllerTest {
 
   private MockMvc mockMvc;
 
-  @MockitoBean private JobRoleRepository jobRoleRepository;
-  @MockitoBean private GetSayingUseCase getSayingUseCase;
   @MockitoBean private CreateInvitationUseCase createInvitationUseCase;
 
   @BeforeEach
@@ -51,56 +42,12 @@ class ResourceControllerTest {
   }
 
   @Test
-  void getJobRoles() throws Exception {
-    given(jobRoleRepository.findAll()).willReturn(JobRoleFixture.defaultJobRoles());
-
-    mockMvc
-        .perform(get("/resource/jobroles"))
-        .andExpect(status().isOk())
-        .andDo(
-            document(
-                "get-job-roles",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                resource(
-                    new ResourceSnippetParametersBuilder()
-                        .tag("JobRole")
-                        .summary("전체 직무 목록 조회")
-                        .responseFields(
-                            fieldWithPath("data.jobRoles[].id").type(STRING).description("직무 ID"),
-                            fieldWithPath("data.jobRoles[].name").type(STRING).description("직무 이름"))
-                        .build())));
-  }
-
-  @Test
-  void getSaying() throws Exception {
-    given(getSayingUseCase.execute()).willReturn(SayingFixture.defaultSaying());
-
-    mockMvc
-        .perform(get("/resource/saying"))
-        .andExpect(status().isOk())
-        .andDo(
-            document(
-                "get-saying",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                resource(
-                    new ResourceSnippetParametersBuilder()
-                        .tag("Saying")
-                        .summary("격언 조회")
-                        .responseFields(
-                            fieldWithPath("data.message").type(STRING).description("격언 내용"),
-                            fieldWithPath("data.from").type(STRING).description("격언 출처"))
-                        .build())));
-  }
-
-  @Test
   void createInvitation() throws Exception {
     String requestBody = InvitationFixture.validInvitationRequestBody();
 
     mockMvc
         .perform(
-            post("/resource/invitations")
+            post("/externals/invitations")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
         .andExpect(status().isOk())
@@ -128,7 +75,7 @@ class ResourceControllerTest {
 
     mockMvc
         .perform(
-            post("/resource/invitations")
+            post("/externals/invitations")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
         .andExpect(status().isBadRequest());

--- a/app/src/test/java/com/growit/app/resource/controller/ExternalControllerTest.java
+++ b/app/src/test/java/com/growit/app/resource/controller/ExternalControllerTest.java
@@ -68,16 +68,4 @@ class ExternalControllerTest {
                             fieldWithPath("data.message").type(STRING).description("응답 메시지"))
                         .build())));
   }
-
-  @Test
-  void createInvitation_InvalidPhoneFormat() throws Exception {
-    String requestBody = InvitationFixture.invalidPhoneFormatRequestBody();
-
-    mockMvc
-        .perform(
-            post("/externals/invitations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-        .andExpect(status().isBadRequest());
-  }
 }

--- a/app/src/test/java/com/growit/app/resource/controller/ResourceControllerTest.java
+++ b/app/src/test/java/com/growit/app/resource/controller/ResourceControllerTest.java
@@ -94,43 +94,4 @@ class ResourceControllerTest {
                         .build())));
   }
 
-  @Test
-  void createInvitation() throws Exception {
-    String requestBody = InvitationFixture.validInvitationRequestBody();
-
-    mockMvc
-        .perform(
-            post("/resource/invitations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-        .andExpect(status().isOk())
-        .andDo(
-            document(
-                "create-invitation",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                resource(
-                    new ResourceSnippetParametersBuilder()
-                        .tag("Invitation")
-                        .summary("초대장 요청 생성")
-                        .requestFields(
-                            fieldWithPath("phone")
-                                .type(STRING)
-                                .description("전화번호 (010-1234-5678 형식)"))
-                        .responseFields(
-                            fieldWithPath("data.message").type(STRING).description("응답 메시지"))
-                        .build())));
-  }
-
-  @Test
-  void createInvitation_InvalidPhoneFormat() throws Exception {
-    String requestBody = InvitationFixture.invalidPhoneFormatRequestBody();
-
-    mockMvc
-        .perform(
-            post("/resource/invitations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-        .andExpect(status().isBadRequest());
-  }
 }

--- a/app/src/test/java/com/growit/app/resource/controller/ResourceControllerTest.java
+++ b/app/src/test/java/com/growit/app/resource/controller/ResourceControllerTest.java
@@ -5,14 +5,12 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.SimpleType.STRING;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
-import com.growit.app.fake.resource.InvitationFixture;
 import com.growit.app.fake.resource.JobRoleFixture;
 import com.growit.app.fake.resource.SayingFixture;
 import com.growit.app.resource.domain.jobrole.repository.JobRoleRepository;
@@ -22,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -93,5 +90,4 @@ class ResourceControllerTest {
                             fieldWithPath("data.from").type(STRING).description("격언 출처"))
                         .build())));
   }
-
 }

--- a/app/src/test/java/com/growit/app/resource/controller/ResourceControllerTest.java
+++ b/app/src/test/java/com/growit/app/resource/controller/ResourceControllerTest.java
@@ -5,6 +5,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.SimpleType.STRING;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -14,11 +15,13 @@ import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
 import com.growit.app.fake.resource.JobRoleFixture;
 import com.growit.app.fake.resource.SayingFixture;
 import com.growit.app.resource.domain.jobrole.repository.JobRoleRepository;
+import com.growit.app.resource.usecase.CreateInvitationUseCase;
 import com.growit.app.resource.usecase.GetSayingUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -36,6 +39,7 @@ class ResourceControllerTest {
 
   @MockitoBean private JobRoleRepository jobRoleRepository;
   @MockitoBean private GetSayingUseCase getSayingUseCase;
+  @MockitoBean private CreateInvitationUseCase createInvitationUseCase;
 
   @BeforeEach
   void setUp(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
@@ -87,5 +91,54 @@ class ResourceControllerTest {
                             fieldWithPath("data.message").type(STRING).description("격언 내용"),
                             fieldWithPath("data.from").type(STRING).description("격언 출처"))
                         .build())));
+  }
+
+  @Test
+  void createInvitation() throws Exception {
+    String requestBody =
+        """
+        {
+          "phone": "010-1234-5678"
+        }
+        """;
+
+    mockMvc
+        .perform(
+            post("/resource/invitations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "create-invitation",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    new ResourceSnippetParametersBuilder()
+                        .tag("Invitation")
+                        .summary("초대장 요청 생성")
+                        .requestFields(
+                            fieldWithPath("phone")
+                                .type(STRING)
+                                .description("전화번호 (010-1234-5678 형식)"))
+                        .responseFields(fieldWithPath("data").type(STRING).description("응답 메시지"))
+                        .build())));
+  }
+
+  @Test
+  void createInvitation_InvalidPhoneFormat() throws Exception {
+    String requestBody =
+        """
+        {
+          "phone": "01012345678"
+        }
+        """;
+
+    mockMvc
+        .perform(
+            post("/resource/invitations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/app/src/test/java/com/growit/app/resource/usecase/CreateInvitationUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/resource/usecase/CreateInvitationUseCaseTest.java
@@ -1,0 +1,30 @@
+package com.growit.app.resource.usecase;
+
+import static org.mockito.Mockito.*;
+
+import com.growit.app.resource.infrastructure.discord.DiscordWebhookClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateInvitationUseCaseTest {
+
+  @Mock private DiscordWebhookClient discordWebhookClient;
+
+  @InjectMocks private CreateInvitationUseCase useCase;
+
+  @Test
+  void givenValidPhone_whenExecute_thenSendDiscordWebhook() {
+    // given
+    String phone = "010-1234-5678";
+
+    // when
+    useCase.execute(phone);
+
+    // then
+    verify(discordWebhookClient, times(1)).sendInvitation(phone);
+  }
+}


### PR DESCRIPTION
- /resource/invitations 엔드포인트 POST 요청 시 초대장 요청 처리
- CreateInvitationUseCase와 DiscordWebhookClient 도입하여 알림 기능 구현
- 유효성 검사 추가 (전화번호 형식 체크)
- 성공/실패 응답 메시지 메시지 리소스에 등록
- 테스트 코드 추가하여 정상/유효성 검사 실패 케이스 검증

## 📌 PR 제목

> 초대 api 연동

---

## ✅ PR 설명

- 어떤 기능/버그 수정인지 간단 설명
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [ ] 코드에 주석/불필요한 로그 제거
- [ ] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
