### PR TITLE
feat: 오늘의 미션(퀘스트) 기능 구현

### DIFF
--- a/app/src/main/java/com/growit/app/resource/usecase/GetSayingUseCase.java
+++ b/app/src/main/java/com/growit/app/resource/usecase/GetSayingUseCase.java
@@ -2,8 +2,8 @@ package com.growit.app.resource.usecase;
 
 import com.growit.app.resource.domain.saying.Saying;
 import com.growit.app.resource.domain.saying.repository.SayingRepository;
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,11 +14,18 @@ public class GetSayingUseCase {
   private static final Saying DEFAULT_SAYING =
       new Saying("tempId", "성공은 매일 반복되는 작은 노력들의 합이다냥!", "그로냥");
 
+  // 요청마다 다른 격언을 보여주기 위한 랜덤 인스턴스
+  private final Random random = new Random();
+
   public Saying execute() {
     final List<Saying> sayings = sayingRepository.findAll();
 
-    return sayings.isEmpty()
-        ? DEFAULT_SAYING
-        : sayings.get(LocalDateTime.now().getMinute() % sayings.size());
+    if (sayings.isEmpty()) {
+      return DEFAULT_SAYING;
+    }
+
+    // 요청마다 랜덤하게 격언 선택 (더 자주 변경됨)
+    int randomIndex = random.nextInt(sayings.size());
+    return sayings.get(randomIndex);
   }
 }


### PR DESCRIPTION
## 📌 PR 제목

> feat: 오늘의 조언 기능 구현

---

## ✅ PR 설명

- 오늘의 미션 필터 관련 기능 구현
- 관련 이슈: #217 
---

- 예시 데이터
```
{
    "data": [
        {
            "id": null,
            "dayOfWeek": "SUNDAY",
            "content": "오늘의 투두 작성하기",
            "type": "DAILY_TODO_WRITE",
            "finished": true
        },
        {
            "id": null,
            "dayOfWeek": "SUNDAY",
            "content": "오늘의 투두 완료하기",
            "type": "DAILY_TODO_COMPLETE",
            "finished": false
        },
        {
            "id": null,
            "dayOfWeek": "SUNDAY",
            "content": "회고 작성하기",
            "type": "WEEKLY_RETROSPECT_WRITE",
            "finished": true
        }
    ]
}
```

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
