### PR TITLE
feat: 회고 내용(content) 필드 추가 및 유효성 검증 로직 구현 (bug/258/retrospect)

### DIFF
--- a/app/src/main/java/com/growit/app/retrospect/controller/retrospect/dto/request/CreateRetrospectRequest.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/retrospect/dto/request/CreateRetrospectRequest.java
@@ -14,5 +14,7 @@ public class CreateRetrospectRequest {
   @NotBlank(message = "{validation.retrospect.plan-id.required}")
   private String planId;
 
+  private String content;
+
   @Valid private KPTDto kpt;
 }

--- a/app/src/main/java/com/growit/app/retrospect/controller/retrospect/mapper/RetrospectRequestMapper.java
+++ b/app/src/main/java/com/growit/app/retrospect/controller/retrospect/mapper/RetrospectRequestMapper.java
@@ -10,11 +10,17 @@ import org.springframework.stereotype.Component;
 public class RetrospectRequestMapper {
 
   public CreateRetrospectCommand toCreateCommand(String userId, CreateRetrospectRequest request) {
-    KPT kpt =
-        new KPT(
-            request.getKpt().getKeep(),
-            request.getKpt().getProblem(),
-            request.getKpt().getTryNext());
+    KPT kpt = null;
+    if (request.getKpt() != null) {
+      kpt =
+          new KPT(
+              request.getKpt().getKeep(),
+              request.getKpt().getProblem(),
+              request.getKpt().getTryNext());
+    } else if (request.getContent() != null) {
+      kpt = new KPT("", "", request.getContent());
+    }
+
     return new CreateRetrospectCommand(request.getGoalId(), request.getPlanId(), userId, kpt);
   }
 

--- a/app/src/main/java/com/growit/app/retrospect/usecase/retrospect/CreateRetrospectUseCase.java
+++ b/app/src/main/java/com/growit/app/retrospect/usecase/retrospect/CreateRetrospectUseCase.java
@@ -1,5 +1,6 @@
 package com.growit.app.retrospect.usecase.retrospect;
 
+import com.growit.app.common.exception.BadRequestException;
 import com.growit.app.goal.domain.goal.service.GoalValidator;
 import com.growit.app.retrospect.domain.retrospect.Retrospect;
 import com.growit.app.retrospect.domain.retrospect.RetrospectRepository;
@@ -18,6 +19,9 @@ public class CreateRetrospectUseCase {
 
   @Transactional
   public String execute(CreateRetrospectCommand command) {
+    if (command.kpt() == null) {
+      throw new BadRequestException("kpt is required");
+    }
     // 계획 존재 여부 확인
     goalValidator.checkPlanExists(command.userId(), command.goalId(), command.planId());
 

--- a/app/src/test/java/com/growit/app/fake/retrospect/RetrospectFixture.java
+++ b/app/src/test/java/com/growit/app/fake/retrospect/RetrospectFixture.java
@@ -51,7 +51,7 @@ public class RetrospectFixture {
 
   public static CreateRetrospectRequest defaultCreateRetrospectRequest() {
     KPTDto kptDto = new KPTDto("계획대로 진행했던 부분을 작성합니다.", "어려웠던 문제점들을 작성합니다.", "다음에 시도해볼 방법들을 작성합니다.");
-    return new CreateRetrospectRequest("goal-123", "plan-456", kptDto);
+    return new CreateRetrospectRequest("goal-123", "plan-456", "", kptDto);
   }
 
   public static CreateRetrospectCommand defaultCreateRetrospectCommand() {

--- a/app/src/test/java/com/growit/app/retrospect/controller/RetrospectControllerTest.java
+++ b/app/src/test/java/com/growit/app/retrospect/controller/RetrospectControllerTest.java
@@ -108,6 +108,9 @@ class RetrospectControllerTest {
                             fieldWithPath("planId")
                                 .type(JsonFieldType.STRING)
                                 .description("계획 아이디"),
+                            fieldWithPath("content")
+                                .type(JsonFieldType.STRING)
+                                .description("회고 내용(v1)"),
                             fieldWithPath("kpt.keep")
                                 .type(JsonFieldType.STRING)
                                 .description("Keep - 계속 유지할 것"),


### PR DESCRIPTION
## 📌 PR 제목

>  retrospect content 필드 수정

---

## ✅ PR 설명

- 어떤 기능/버그 수정인지 간단 설명
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [ ] 로컬 테스트 완료
- [ ] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [ ] 코드에 주석/불필요한 로그 제거
- [ ] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
