### PR TITLE
feat(mentor): 멘토의 조언과 목표 추천을 위해 데이터 수집 및 생성 구현

### DIFF
--- a/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceDataCollector.java
+++ b/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceDataCollector.java
@@ -1,0 +1,90 @@
+package com.growit.app.advice.domain.mentor.service;
+
+import com.growit.app.advice.domain.mentor.vo.MentorAdviceData;
+import com.growit.app.goal.domain.goal.Goal;
+import com.growit.app.goal.domain.goal.plan.Plan;
+import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospect;
+import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospectRepository;
+import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.ToDoRepository;
+import com.growit.app.user.domain.user.User;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 멘토 조언 생성에 필요한 데이터를 수집하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class MentorAdviceDataCollector {
+
+  private final ToDoRepository toDoRepository;
+  private final GoalRetrospectRepository goalRetrospectRepository;
+
+  /**
+   * 멘토 조언에 필요한 모든 데이터를 수집합니다.
+   *
+   * @param user 사용자
+   * @param goal 현재 목표
+   * @return 수집된 데이터
+   */
+  public MentorAdviceData collectData(User user, Goal goal) {
+    LocalDate today = LocalDate.now();
+    LocalDate aWeekAgo = today.minusWeeks(1);
+
+    List<ToDo> weeklyTodos = getWeeklyTodos(user.getId(), aWeekAgo, today);
+    List<String> weeklyRetrospects = getWeeklyRetrospects(goal.getId(), aWeekAgo, today);
+
+    return MentorAdviceData.builder()
+        .recentTodos(extractIncompleteTodoContents(weeklyTodos))
+        .completedTodos(extractCompletedTodoContents(weeklyTodos))
+        .incompleteTodos(extractIncompleteTodoContents(weeklyTodos))
+        .weeklyRetrospects(weeklyRetrospects)
+        .pastWeeklyGoals(extractWeeklyGoalContents(goal))
+        .overallGoal(goal.getName())
+        .build();
+  }
+
+  private List<ToDo> getWeeklyTodos(String userId, LocalDate startDate, LocalDate endDate) {
+    return toDoRepository.findAllByUserIdAndCreatedAtBetween(
+        userId, 
+        startDate.atStartOfDay(), 
+        endDate.atTime(23, 59, 59)
+    );
+  }
+
+  private List<String> getWeeklyRetrospects(String goalId, LocalDate startDate, LocalDate endDate) {
+    return goalRetrospectRepository
+        .findAllByGoalIdAndCreatedAtBetween(
+            goalId, 
+            startDate.atStartOfDay(), 
+            endDate.atTime(23, 59, 59)
+        )
+        .stream()
+        .map(GoalRetrospect::getContent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractCompletedTodoContents(List<ToDo> todos) {
+    return todos.stream()
+        .filter(ToDo::isCompleted)
+        .map(ToDo::getContent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractIncompleteTodoContents(List<ToDo> todos) {
+    return todos.stream()
+        .filter(todo -> !todo.isCompleted())
+        .map(ToDo::getContent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractWeeklyGoalContents(Goal goal) {
+    return goal.getPlans().stream()
+        .map(Plan::getContent)
+        .collect(Collectors.toList());
+  }
+}

--- a/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceDataCollector.java
+++ b/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceDataCollector.java
@@ -14,9 +14,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * 멘토 조언 생성에 필요한 데이터를 수집하는 서비스
- */
+/** 멘토 조언 생성에 필요한 데이터를 수집하는 서비스 */
 @Service
 @RequiredArgsConstructor
 public class MentorAdviceDataCollector {
@@ -50,19 +48,13 @@ public class MentorAdviceDataCollector {
 
   private List<ToDo> getWeeklyTodos(String userId, LocalDate startDate, LocalDate endDate) {
     return toDoRepository.findAllByUserIdAndCreatedAtBetween(
-        userId, 
-        startDate.atStartOfDay(), 
-        endDate.atTime(23, 59, 59)
-    );
+        userId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
   }
 
   private List<String> getWeeklyRetrospects(String goalId, LocalDate startDate, LocalDate endDate) {
     return goalRetrospectRepository
         .findAllByGoalIdAndCreatedAtBetween(
-            goalId, 
-            startDate.atStartOfDay(), 
-            endDate.atTime(23, 59, 59)
-        )
+            goalId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59))
         .stream()
         .map(GoalRetrospect::getContent)
         .collect(Collectors.toList());
@@ -83,8 +75,6 @@ public class MentorAdviceDataCollector {
   }
 
   private List<String> extractWeeklyGoalContents(Goal goal) {
-    return goal.getPlans().stream()
-        .map(Plan::getContent)
-        .collect(Collectors.toList());
+    return goal.getPlans().stream().map(Plan::getContent).collect(Collectors.toList());
   }
 }

--- a/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceService.java
+++ b/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceService.java
@@ -10,12 +10,7 @@ import com.growit.app.user.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * 멘토 조언 생성을 담당하는 도메인 서비스
- * - AI 요청 생성
- * - AI 호출
- * - 멘토 조언 객체 생성
- */
+/** 멘토 조언 생성을 담당하는 도메인 서비스 - AI 요청 생성 - AI 호출 - 멘토 조언 객체 생성 */
 @Service
 @RequiredArgsConstructor
 public class MentorAdviceService {
@@ -33,19 +28,20 @@ public class MentorAdviceService {
   public MentorAdvice generateAdvice(User user, Goal goal, MentorAdviceData data) {
     AiMentorAdviceRequest request = createAiRequest(user, goal, data);
     AiMentorAdviceResponse response = aiMentorAdviceClient.getMentorAdvice(request);
-    
+
     return createMentorAdvice(user, goal, response);
   }
 
   private AiMentorAdviceRequest createAiRequest(User user, Goal goal, MentorAdviceData data) {
-    AiMentorAdviceRequest.Input input = AiMentorAdviceRequest.Input.builder()
-        .recentTodos(data.getRecentTodos())
-        .weeklyRetrospects(data.getWeeklyRetrospects())
-        .overallGoal(data.getOverallGoal())
-        .completedTodos(data.getCompletedTodos())
-        .incompleteTodos(data.getIncompleteTodos())
-        .pastWeeklyGoals(data.getPastWeeklyGoals())
-        .build();
+    AiMentorAdviceRequest.Input input =
+        AiMentorAdviceRequest.Input.builder()
+            .recentTodos(data.getRecentTodos())
+            .weeklyRetrospects(data.getWeeklyRetrospects())
+            .overallGoal(data.getOverallGoal())
+            .completedTodos(data.getCompletedTodos())
+            .incompleteTodos(data.getIncompleteTodos())
+            .pastWeeklyGoals(data.getPastWeeklyGoals())
+            .build();
 
     return AiMentorAdviceRequest.builder()
         .userId(user.getId())
@@ -61,10 +57,11 @@ public class MentorAdviceService {
         .goalId(goal.getId())
         .isChecked(false)
         .message("AI Mentor's Advice")
-        .kpt(new MentorAdvice.Kpt(
-            response.getOutput().getKeep(),
-            response.getOutput().getProblem(),
-            response.getOutput().getTryNext()))
+        .kpt(
+            new MentorAdvice.Kpt(
+                response.getOutput().getKeep(),
+                response.getOutput().getProblem(),
+                response.getOutput().getTryNext()))
         .build();
   }
 }

--- a/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceService.java
+++ b/app/src/main/java/com/growit/app/advice/domain/mentor/service/MentorAdviceService.java
@@ -1,0 +1,70 @@
+package com.growit.app.advice.domain.mentor.service;
+
+import com.growit.app.advice.domain.mentor.MentorAdvice;
+import com.growit.app.advice.domain.mentor.vo.MentorAdviceData;
+import com.growit.app.advice.usecase.dto.ai.AiMentorAdviceRequest;
+import com.growit.app.advice.usecase.dto.ai.AiMentorAdviceResponse;
+import com.growit.app.common.util.IDGenerator;
+import com.growit.app.goal.domain.goal.Goal;
+import com.growit.app.user.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 멘토 조언 생성을 담당하는 도메인 서비스
+ * - AI 요청 생성
+ * - AI 호출
+ * - 멘토 조언 객체 생성
+ */
+@Service
+@RequiredArgsConstructor
+public class MentorAdviceService {
+
+  private final AiMentorAdviceClient aiMentorAdviceClient;
+
+  /**
+   * 멘토 조언을 생성합니다.
+   *
+   * @param user 사용자
+   * @param goal 현재 목표
+   * @param data 조언 생성에 필요한 데이터
+   * @return 생성된 멘토 조언
+   */
+  public MentorAdvice generateAdvice(User user, Goal goal, MentorAdviceData data) {
+    AiMentorAdviceRequest request = createAiRequest(user, goal, data);
+    AiMentorAdviceResponse response = aiMentorAdviceClient.getMentorAdvice(request);
+    
+    return createMentorAdvice(user, goal, response);
+  }
+
+  private AiMentorAdviceRequest createAiRequest(User user, Goal goal, MentorAdviceData data) {
+    AiMentorAdviceRequest.Input input = AiMentorAdviceRequest.Input.builder()
+        .recentTodos(data.getRecentTodos())
+        .weeklyRetrospects(data.getWeeklyRetrospects())
+        .overallGoal(data.getOverallGoal())
+        .completedTodos(data.getCompletedTodos())
+        .incompleteTodos(data.getIncompleteTodos())
+        .pastWeeklyGoals(data.getPastWeeklyGoals())
+        .build();
+
+    return AiMentorAdviceRequest.builder()
+        .userId(user.getId())
+        .promptId(goal.getMentor().getAdvicePromptId())
+        .input(input)
+        .build();
+  }
+
+  private MentorAdvice createMentorAdvice(User user, Goal goal, AiMentorAdviceResponse response) {
+    return MentorAdvice.builder()
+        .id(IDGenerator.generateId())
+        .userId(user.getId())
+        .goalId(goal.getId())
+        .isChecked(false)
+        .message("AI Mentor's Advice")
+        .kpt(new MentorAdvice.Kpt(
+            response.getOutput().getKeep(),
+            response.getOutput().getProblem(),
+            response.getOutput().getTryNext()))
+        .build();
+  }
+}

--- a/app/src/main/java/com/growit/app/advice/domain/mentor/vo/MentorAdviceData.java
+++ b/app/src/main/java/com/growit/app/advice/domain/mentor/vo/MentorAdviceData.java
@@ -1,0 +1,20 @@
+package com.growit.app.advice.domain.mentor.vo;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 멘토 조언 생성에 필요한 데이터를 담는 값 객체
+ */
+@Getter
+@Builder
+public class MentorAdviceData {
+  
+  private final List<String> recentTodos;
+  private final List<String> completedTodos;
+  private final List<String> incompleteTodos;
+  private final List<String> weeklyRetrospects;
+  private final List<String> pastWeeklyGoals;
+  private final String overallGoal;
+}

--- a/app/src/main/java/com/growit/app/advice/domain/mentor/vo/MentorAdviceData.java
+++ b/app/src/main/java/com/growit/app/advice/domain/mentor/vo/MentorAdviceData.java
@@ -4,13 +4,11 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 멘토 조언 생성에 필요한 데이터를 담는 값 객체
- */
+/** 멘토 조언 생성에 필요한 데이터를 담는 값 객체 */
 @Getter
 @Builder
 public class MentorAdviceData {
-  
+
   private final List<String> recentTodos;
   private final List<String> completedTodos;
   private final List<String> incompleteTodos;

--- a/app/src/main/java/com/growit/app/advice/usecase/GenerateMentorAdviceUseCase.java
+++ b/app/src/main/java/com/growit/app/advice/usecase/GenerateMentorAdviceUseCase.java
@@ -13,12 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 멘토 조언 생성 UseCase
- * - 진행 중인 목표 확인
- * - 조언 데이터 수집
- * - AI 조언 생성
- */
+/** 멘토 조언 생성 UseCase - 진행 중인 목표 확인 - 조언 데이터 수집 - AI 조언 생성 */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -38,7 +33,7 @@ public class GenerateMentorAdviceUseCase {
   public MentorAdvice execute(User user) {
     Goal currentGoal = getCurrentProgressGoal(user);
     MentorAdviceData data = dataCollector.collectData(user, currentGoal);
-    
+
     return mentorAdviceService.generateAdvice(user, currentGoal, data);
   }
 

--- a/app/src/main/java/com/growit/app/advice/usecase/GenerateMentorAdviceUseCase.java
+++ b/app/src/main/java/com/growit/app/advice/usecase/GenerateMentorAdviceUseCase.java
@@ -1,104 +1,50 @@
 package com.growit.app.advice.usecase;
 
 import com.growit.app.advice.domain.mentor.MentorAdvice;
-import com.growit.app.advice.domain.mentor.service.AiMentorAdviceClient;
-import com.growit.app.advice.usecase.dto.ai.AiMentorAdviceRequest;
-import com.growit.app.advice.usecase.dto.ai.AiMentorAdviceResponse;
+import com.growit.app.advice.domain.mentor.service.MentorAdviceDataCollector;
+import com.growit.app.advice.domain.mentor.service.MentorAdviceService;
+import com.growit.app.advice.domain.mentor.vo.MentorAdviceData;
 import com.growit.app.common.exception.NotFoundException;
-import com.growit.app.common.util.IDGenerator;
 import com.growit.app.goal.domain.goal.Goal;
-import com.growit.app.goal.domain.goal.plan.Plan;
 import com.growit.app.goal.domain.goal.vo.GoalStatus;
 import com.growit.app.goal.usecase.GetUserGoalsUseCase;
-import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospect;
-import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospectRepository;
-import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.ToDoRepository;
 import com.growit.app.user.domain.user.User;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 멘토 조언 생성 UseCase
+ * - 진행 중인 목표 확인
+ * - 조언 데이터 수집
+ * - AI 조언 생성
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class GenerateMentorAdviceUseCase {
 
-  private final AiMentorAdviceClient aiMentorAdviceClient;
   private final GetUserGoalsUseCase getUserGoalsUseCase;
-  private final ToDoRepository toDoRepository;
-  private final GoalRetrospectRepository goalRetrospectRepository;
+  private final MentorAdviceDataCollector dataCollector;
+  private final MentorAdviceService mentorAdviceService;
 
+  /**
+   * 멘토 조언을 생성합니다.
+   *
+   * @param user 사용자
+   * @return 생성된 멘토 조언
+   * @throws NotFoundException 진행 중인 목표가 없는 경우
+   */
   public MentorAdvice execute(User user) {
-    Goal currentGoal =
-        getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS).stream()
-            .findFirst()
-            .orElseThrow(() -> new NotFoundException("진행중인 목표가 없습니다."));
+    Goal currentGoal = getCurrentProgressGoal(user);
+    MentorAdviceData data = dataCollector.collectData(user, currentGoal);
+    
+    return mentorAdviceService.generateAdvice(user, currentGoal, data);
+  }
 
-    LocalDate today = LocalDate.now();
-    LocalDate aWeekAgo = today.minusWeeks(1);
-
-    List<ToDo> weeklyTodos =
-        toDoRepository.findAllByUserIdAndCreatedAtBetween(
-            user.getId(), aWeekAgo.atStartOfDay(), today.atTime(23, 59, 59));
-
-    List<String> completedTodos =
-        weeklyTodos.stream()
-            .filter(ToDo::isCompleted)
-            .map(ToDo::getContent)
-            .collect(Collectors.toList());
-
-    List<String> incompleteTodos =
-        weeklyTodos.stream()
-            .filter(todo -> !todo.isCompleted())
-            .map(ToDo::getContent)
-            .collect(Collectors.toList());
-
-    List<String> weeklyRetrospects =
-        goalRetrospectRepository
-            .findAllByGoalIdAndCreatedAtBetween(
-                currentGoal.getId(), aWeekAgo.atStartOfDay(), today.atTime(23, 59, 59))
-            .stream()
-            .map(GoalRetrospect::getContent)
-            .collect(Collectors.toList());
-
-    AiMentorAdviceRequest.Input input =
-        AiMentorAdviceRequest.Input.builder()
-            .recentTodos(incompleteTodos)
-            .weeklyRetrospects(weeklyRetrospects)
-            .overallGoal(currentGoal.getName())
-            .completedTodos(completedTodos)
-            .incompleteTodos(incompleteTodos)
-            .pastWeeklyGoals(
-                currentGoal.getPlans().stream().map(Plan::getContent).collect(Collectors.toList()))
-            .build();
-
-    // teamcook-advice-001, confucius-advice-001, warren-buffett-advice-001
-    String promptId = currentGoal.getMentor().getAdvicePromptId();
-
-    AiMentorAdviceRequest request =
-        AiMentorAdviceRequest.builder()
-            .userId(user.getId())
-            .promptId(promptId)
-            .input(input)
-            .build();
-
-    AiMentorAdviceResponse response = aiMentorAdviceClient.getMentorAdvice(request);
-
-    return MentorAdvice.builder()
-        .id(IDGenerator.generateId())
-        .userId(user.getId())
-        .goalId(currentGoal.getId())
-        .isChecked(false)
-        .message("AI Mentor's Advice")
-        .kpt(
-            new MentorAdvice.Kpt(
-                response.getOutput().getKeep(),
-                response.getOutput().getProblem(),
-                response.getOutput().getTryNext()))
-        .build();
+  private Goal getCurrentProgressGoal(User user) {
+    return getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS).stream()
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException("진행중인 목표가 없습니다."));
   }
 }

--- a/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationDataCollector.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationDataCollector.java
@@ -1,0 +1,117 @@
+package com.growit.app.goal.domain.goalrecommendation.service;
+
+import com.growit.app.goal.domain.goal.Goal;
+import com.growit.app.goal.domain.goal.plan.Plan;
+import com.growit.app.goal.domain.goalrecommendation.vo.GoalRecommendationData;
+import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospect;
+import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospectRepository;
+import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.ToDoRepository;
+import com.growit.app.user.domain.user.User;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 목표 추천 생성에 필요한 데이터를 수집하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class GoalRecommendationDataCollector {
+
+  private final ToDoRepository toDoRepository;
+  private final GoalRetrospectRepository goalRetrospectRepository;
+
+  /**
+   * 목표 추천에 필요한 모든 데이터를 수집합니다.
+   *
+   * @param user 사용자
+   * @param goal 현재 목표
+   * @return 수집된 데이터
+   */
+  public GoalRecommendationData collectData(User user, Goal goal) {
+    LocalDate today = LocalDate.now();
+    LocalDate aMonthAgo = today.minusMonths(1);
+
+    List<ToDo> monthlyTodos = getMonthlyTodos(user.getId(), aMonthAgo, today);
+    List<String> pastRetrospects = getPastRetrospects(goal.getId(), aMonthAgo, today);
+
+    return GoalRecommendationData.builder()
+        .pastTodos(extractTodoContents(monthlyTodos))
+        .completedTodos(extractCompletedTodoContents(monthlyTodos))
+        .pastRetrospects(pastRetrospects)
+        .pastWeeklyGoals(extractWeeklyGoalContents(goal))
+        .remainingTime(calculateRemainingTime(goal))
+        .build();
+  }
+
+  private List<ToDo> getMonthlyTodos(String userId, LocalDate startDate, LocalDate endDate) {
+    return toDoRepository.findAllByUserIdAndCreatedAtBetween(
+        userId, 
+        startDate.atStartOfDay(), 
+        endDate.atTime(23, 59, 59)
+    );
+  }
+
+  private List<String> getPastRetrospects(String goalId, LocalDate startDate, LocalDate endDate) {
+    return goalRetrospectRepository
+        .findAllByGoalIdAndCreatedAtBetween(
+            goalId, 
+            startDate.atStartOfDay(), 
+            endDate.atTime(23, 59, 59)
+        )
+        .stream()
+        .map(GoalRetrospect::getContent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractTodoContents(List<ToDo> todos) {
+    return todos.stream()
+        .map(ToDo::getContent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractCompletedTodoContents(List<ToDo> todos) {
+    return todos.stream()
+        .filter(ToDo::isCompleted)
+        .map(ToDo::getContent)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> extractWeeklyGoalContents(Goal goal) {
+    return goal.getPlans().stream()
+        .map(Plan::getContent)
+        .filter(content -> content != null && !content.isBlank())
+        .collect(Collectors.toList());
+  }
+
+  private String calculateRemainingTime(Goal goal) {
+    LocalDate today = LocalDate.now();
+    LocalDate dueDate = goal.getDuration().endDate();
+
+    if (dueDate == null) {
+      return "기간 정보 없음";
+    }
+
+    if (today.isAfter(dueDate)) {
+      return "목표 기간 종료";
+    }
+
+    Period period = Period.between(today, dueDate);
+    int months = period.getMonths();
+    int days = period.getDays();
+
+    if (months > 0 && days > 0) {
+      return String.format("%d개월 %d일 남음", months, days);
+    } else if (months > 0) {
+      return String.format("%d개월 남음", months);
+    } else if (days > 0) {
+      return String.format("%d일 남음", days);
+    } else {
+      return "오늘 마감";
+    }
+  }
+}

--- a/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationDataCollector.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationDataCollector.java
@@ -15,9 +15,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * 목표 추천 생성에 필요한 데이터를 수집하는 서비스
- */
+/** 목표 추천 생성에 필요한 데이터를 수집하는 서비스 */
 @Service
 @RequiredArgsConstructor
 public class GoalRecommendationDataCollector {
@@ -50,28 +48,20 @@ public class GoalRecommendationDataCollector {
 
   private List<ToDo> getMonthlyTodos(String userId, LocalDate startDate, LocalDate endDate) {
     return toDoRepository.findAllByUserIdAndCreatedAtBetween(
-        userId, 
-        startDate.atStartOfDay(), 
-        endDate.atTime(23, 59, 59)
-    );
+        userId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
   }
 
   private List<String> getPastRetrospects(String goalId, LocalDate startDate, LocalDate endDate) {
     return goalRetrospectRepository
         .findAllByGoalIdAndCreatedAtBetween(
-            goalId, 
-            startDate.atStartOfDay(), 
-            endDate.atTime(23, 59, 59)
-        )
+            goalId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59))
         .stream()
         .map(GoalRetrospect::getContent)
         .collect(Collectors.toList());
   }
 
   private List<String> extractTodoContents(List<ToDo> todos) {
-    return todos.stream()
-        .map(ToDo::getContent)
-        .collect(Collectors.toList());
+    return todos.stream().map(ToDo::getContent).collect(Collectors.toList());
   }
 
   private List<String> extractCompletedTodoContents(List<ToDo> todos) {

--- a/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationService.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationService.java
@@ -1,0 +1,77 @@
+package com.growit.app.goal.domain.goalrecommendation.service;
+
+import com.growit.app.advice.domain.mentor.service.AiMentorAdviceClient;
+import com.growit.app.advice.usecase.dto.ai.AiGoalRecommendationRequest;
+import com.growit.app.advice.usecase.dto.ai.AiGoalRecommendationResponse;
+import com.growit.app.common.util.IDGenerator;
+import com.growit.app.goal.domain.goal.Goal;
+import com.growit.app.goal.domain.goal.plan.Plan;
+import com.growit.app.goal.domain.planrecommendation.PlanRecommendation;
+import com.growit.app.goal.domain.goalrecommendation.vo.GoalRecommendationData;
+import com.growit.app.user.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 목표 추천 생성을 담당하는 도메인 서비스
+ * - AI 요청 생성
+ * - AI 호출
+ * - 추천 객체 생성
+ */
+@Service
+@RequiredArgsConstructor
+public class GoalRecommendationService {
+
+  private final AiMentorAdviceClient aiMentorAdviceClient;
+
+  /**
+   * 목표 추천을 생성합니다.
+   *
+   * @param user 사용자
+   * @param goal 현재 목표
+   * @param data 추천 생성에 필요한 데이터
+   * @return 생성된 계획 추천
+   */
+  public PlanRecommendation generateRecommendation(User user, Goal goal, GoalRecommendationData data) {
+    AiGoalRecommendationRequest request = createAiRequest(user, goal, data);
+    AiGoalRecommendationResponse response = aiMentorAdviceClient.getGoalRecommendation(request);
+    
+    Plan targetPlan = selectTargetPlan(goal);
+    
+    return createPlanRecommendation(user, goal, targetPlan, response.getOutput());
+  }
+
+  private AiGoalRecommendationRequest createAiRequest(User user, Goal goal, GoalRecommendationData data) {
+    AiGoalRecommendationRequest.Input input = AiGoalRecommendationRequest.Input.builder()
+        .pastTodos(data.getPastTodos())
+        .pastRetrospects(data.getPastRetrospects())
+        .overallGoal(goal.getName())
+        .completedTodos(data.getCompletedTodos())
+        .pastWeeklyGoals(data.getPastWeeklyGoals())
+        .remainingTime(data.getRemainingTime())
+        .build();
+
+    return AiGoalRecommendationRequest.builder()
+        .userId(user.getId())
+        .promptId(goal.getMentor().getGoalPromprtId())
+        .input(input)
+        .build();
+  }
+
+  private Plan selectTargetPlan(Goal goal) {
+    return goal.getPlans().stream()
+        .filter(Plan::isCurrentWeek)
+        .findFirst()
+        .orElse(goal.getPlans().get(0));
+  }
+
+  private PlanRecommendation createPlanRecommendation(User user, Goal goal, Plan targetPlan, String content) {
+    return new PlanRecommendation(
+        IDGenerator.generateId(),
+        user.getId(),
+        goal.getId(),
+        targetPlan.getId(),
+        content
+    );
+  }
+}

--- a/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationService.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/service/GoalRecommendationService.java
@@ -6,18 +6,13 @@ import com.growit.app.advice.usecase.dto.ai.AiGoalRecommendationResponse;
 import com.growit.app.common.util.IDGenerator;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.goal.domain.goal.plan.Plan;
-import com.growit.app.goal.domain.planrecommendation.PlanRecommendation;
 import com.growit.app.goal.domain.goalrecommendation.vo.GoalRecommendationData;
+import com.growit.app.goal.domain.planrecommendation.PlanRecommendation;
 import com.growit.app.user.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * 목표 추천 생성을 담당하는 도메인 서비스
- * - AI 요청 생성
- * - AI 호출
- * - 추천 객체 생성
- */
+/** 목표 추천 생성을 담당하는 도메인 서비스 - AI 요청 생성 - AI 호출 - 추천 객체 생성 */
 @Service
 @RequiredArgsConstructor
 public class GoalRecommendationService {
@@ -32,24 +27,27 @@ public class GoalRecommendationService {
    * @param data 추천 생성에 필요한 데이터
    * @return 생성된 계획 추천
    */
-  public PlanRecommendation generateRecommendation(User user, Goal goal, GoalRecommendationData data) {
+  public PlanRecommendation generateRecommendation(
+      User user, Goal goal, GoalRecommendationData data) {
     AiGoalRecommendationRequest request = createAiRequest(user, goal, data);
     AiGoalRecommendationResponse response = aiMentorAdviceClient.getGoalRecommendation(request);
-    
+
     Plan targetPlan = selectTargetPlan(goal);
-    
+
     return createPlanRecommendation(user, goal, targetPlan, response.getOutput());
   }
 
-  private AiGoalRecommendationRequest createAiRequest(User user, Goal goal, GoalRecommendationData data) {
-    AiGoalRecommendationRequest.Input input = AiGoalRecommendationRequest.Input.builder()
-        .pastTodos(data.getPastTodos())
-        .pastRetrospects(data.getPastRetrospects())
-        .overallGoal(goal.getName())
-        .completedTodos(data.getCompletedTodos())
-        .pastWeeklyGoals(data.getPastWeeklyGoals())
-        .remainingTime(data.getRemainingTime())
-        .build();
+  private AiGoalRecommendationRequest createAiRequest(
+      User user, Goal goal, GoalRecommendationData data) {
+    AiGoalRecommendationRequest.Input input =
+        AiGoalRecommendationRequest.Input.builder()
+            .pastTodos(data.getPastTodos())
+            .pastRetrospects(data.getPastRetrospects())
+            .overallGoal(goal.getName())
+            .completedTodos(data.getCompletedTodos())
+            .pastWeeklyGoals(data.getPastWeeklyGoals())
+            .remainingTime(data.getRemainingTime())
+            .build();
 
     return AiGoalRecommendationRequest.builder()
         .userId(user.getId())
@@ -65,13 +63,9 @@ public class GoalRecommendationService {
         .orElse(goal.getPlans().get(0));
   }
 
-  private PlanRecommendation createPlanRecommendation(User user, Goal goal, Plan targetPlan, String content) {
+  private PlanRecommendation createPlanRecommendation(
+      User user, Goal goal, Plan targetPlan, String content) {
     return new PlanRecommendation(
-        IDGenerator.generateId(),
-        user.getId(),
-        goal.getId(),
-        targetPlan.getId(),
-        content
-    );
+        IDGenerator.generateId(), user.getId(), goal.getId(), targetPlan.getId(), content);
   }
 }

--- a/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/vo/GoalRecommendationData.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/vo/GoalRecommendationData.java
@@ -1,0 +1,33 @@
+package com.growit.app.goal.domain.goalrecommendation.vo;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 목표 추천 생성에 필요한 데이터를 담는 값 객체
+ */
+@Getter
+@Builder
+public class GoalRecommendationData {
+  
+  private final List<String> pastTodos;
+  private final List<String> completedTodos;
+  private final List<String> pastRetrospects;
+  private final List<String> pastWeeklyGoals;
+  private final String remainingTime;
+
+  /**
+   * 빈 회고가 있는지 확인하고 필요시 빈 문자열을 추가합니다.
+   * AI 서버의 최소 1개 항목 요구사항을 만족시키기 위함입니다.
+   */
+  public static class GoalRecommendationDataBuilder {
+    public GoalRecommendationDataBuilder pastRetrospects(List<String> pastRetrospects) {
+      if (pastRetrospects.isEmpty()) {
+        pastRetrospects.add("");
+      }
+      this.pastRetrospects = pastRetrospects;
+      return this;
+    }
+  }
+}

--- a/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/vo/GoalRecommendationData.java
+++ b/app/src/main/java/com/growit/app/goal/domain/goalrecommendation/vo/GoalRecommendationData.java
@@ -4,23 +4,18 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 목표 추천 생성에 필요한 데이터를 담는 값 객체
- */
+/** 목표 추천 생성에 필요한 데이터를 담는 값 객체 */
 @Getter
 @Builder
 public class GoalRecommendationData {
-  
+
   private final List<String> pastTodos;
   private final List<String> completedTodos;
   private final List<String> pastRetrospects;
   private final List<String> pastWeeklyGoals;
   private final String remainingTime;
 
-  /**
-   * 빈 회고가 있는지 확인하고 필요시 빈 문자열을 추가합니다.
-   * AI 서버의 최소 1개 항목 요구사항을 만족시키기 위함입니다.
-   */
+  /** 빈 회고가 있는지 확인하고 필요시 빈 문자열을 추가합니다. AI 서버의 최소 1개 항목 요구사항을 만족시키기 위함입니다. */
   public static class GoalRecommendationDataBuilder {
     public GoalRecommendationDataBuilder pastRetrospects(List<String> pastRetrospects) {
       if (pastRetrospects.isEmpty()) {

--- a/app/src/main/java/com/growit/app/goal/usecase/GenerateGoalRecommendationUseCase.java
+++ b/app/src/main/java/com/growit/app/goal/usecase/GenerateGoalRecommendationUseCase.java
@@ -13,13 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 목표 추천 생성 UseCase
- * - 진행 중인 목표 확인
- * - 추천 데이터 수집
- * - AI 추천 생성
- * - 추천 저장
- */
+/** 목표 추천 생성 UseCase - 진행 중인 목표 확인 - 추천 데이터 수집 - AI 추천 생성 - 추천 저장 */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -40,10 +34,11 @@ public class GenerateGoalRecommendationUseCase {
   public PlanRecommendation execute(User user) {
     Goal currentGoal = getCurrentProgressGoal(user);
     GoalRecommendationData data = dataCollector.collectData(user, currentGoal);
-    PlanRecommendation recommendation = recommendationService.generateRecommendation(user, currentGoal, data);
-    
+    PlanRecommendation recommendation =
+        recommendationService.generateRecommendation(user, currentGoal, data);
+
     planRecommendationRepository.save(recommendation);
-    
+
     return recommendation;
   }
 

--- a/app/src/main/java/com/growit/app/goal/usecase/GenerateGoalRecommendationUseCase.java
+++ b/app/src/main/java/com/growit/app/goal/usecase/GenerateGoalRecommendationUseCase.java
@@ -1,142 +1,55 @@
 package com.growit.app.goal.usecase;
 
-import com.growit.app.advice.domain.mentor.service.AiMentorAdviceClient;
-import com.growit.app.advice.usecase.dto.ai.AiGoalRecommendationRequest;
-import com.growit.app.advice.usecase.dto.ai.AiGoalRecommendationResponse;
 import com.growit.app.common.exception.NotFoundException;
-import com.growit.app.common.util.IDGenerator;
 import com.growit.app.goal.domain.goal.Goal;
-import com.growit.app.goal.domain.goal.plan.Plan;
 import com.growit.app.goal.domain.goal.vo.GoalStatus;
+import com.growit.app.goal.domain.goalrecommendation.service.GoalRecommendationDataCollector;
+import com.growit.app.goal.domain.goalrecommendation.service.GoalRecommendationService;
+import com.growit.app.goal.domain.goalrecommendation.vo.GoalRecommendationData;
 import com.growit.app.goal.domain.planrecommendation.PlanRecommendation;
 import com.growit.app.goal.domain.planrecommendation.PlanRecommendationRepository;
-import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospect;
-import com.growit.app.retrospect.domain.goalretrospect.GoalRetrospectRepository;
-import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.ToDoRepository;
 import com.growit.app.user.domain.user.User;
-import java.time.LocalDate;
-import java.time.Period;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 목표 추천 생성 UseCase
+ * - 진행 중인 목표 확인
+ * - 추천 데이터 수집
+ * - AI 추천 생성
+ * - 추천 저장
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class GenerateGoalRecommendationUseCase {
 
-  private final AiMentorAdviceClient aiMentorAdviceClient;
   private final GetUserGoalsUseCase getUserGoalsUseCase;
-  private final ToDoRepository toDoRepository;
-  private final GoalRetrospectRepository goalRetrospectRepository;
+  private final GoalRecommendationDataCollector dataCollector;
+  private final GoalRecommendationService recommendationService;
   private final PlanRecommendationRepository planRecommendationRepository;
 
+  /**
+   * 목표 추천을 생성합니다.
+   *
+   * @param user 사용자
+   * @return 생성된 계획 추천
+   * @throws NotFoundException 진행 중인 목표가 없는 경우
+   */
   public PlanRecommendation execute(User user) {
-    Goal currentGoal =
-        getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS).stream()
-            .findFirst()
-            .orElseThrow(() -> new NotFoundException("진행중인 목표가 없습니다."));
-
-    LocalDate today = LocalDate.now();
-    LocalDate aMonthAgo = today.minusMonths(1);
-
-    List<ToDo> monthlyTodos =
-        toDoRepository.findAllByUserIdAndCreatedAtBetween(
-            user.getId(), aMonthAgo.atStartOfDay(), today.atTime(23, 59, 59));
-
-    List<String> pastTodos =
-        monthlyTodos.stream().map(ToDo::getContent).collect(Collectors.toList());
-
-    List<String> completedTodos =
-        monthlyTodos.stream()
-            .filter(ToDo::isCompleted)
-            .map(ToDo::getContent)
-            .collect(Collectors.toList());
-
-    List<String> pastRetrospects =
-        goalRetrospectRepository
-            .findAllByGoalIdAndCreatedAtBetween(
-                currentGoal.getId(), aMonthAgo.atStartOfDay(), today.atTime(23, 59, 59))
-            .stream()
-            .map(GoalRetrospect::getContent)
-            .collect(Collectors.toList());
-
-    if (pastRetrospects.isEmpty()) {
-      pastRetrospects.add("");
-    }
-
-    String remainingTime = calculateRemainingTime(currentGoal);
-
-    AiGoalRecommendationRequest.Input input =
-        AiGoalRecommendationRequest.Input.builder()
-            .pastTodos(pastTodos)
-            .pastRetrospects(pastRetrospects)
-            .overallGoal(currentGoal.getName())
-            .completedTodos(completedTodos)
-            .pastWeeklyGoals(
-                currentGoal.getPlans().stream()
-                    .map(Plan::getContent)
-                    .filter(content -> content != null && !content.isBlank())
-                    .collect(Collectors.toList()))
-            .remainingTime(remainingTime)
-            .build();
-
-    AiGoalRecommendationRequest request =
-        AiGoalRecommendationRequest.builder()
-            .userId(user.getId())
-            .promptId(currentGoal.getMentor().getGoalPromprtId())
-            .input(input)
-            .build();
-
-    AiGoalRecommendationResponse response = aiMentorAdviceClient.getGoalRecommendation(request);
-
-    // 현재 주차의 계획을 찾거나, 없으면 첫 번째 계획을 사용
-    Plan targetPlan =
-        currentGoal.getPlans().stream()
-            .filter(Plan::isCurrentWeek)
-            .findFirst()
-            .orElse(currentGoal.getPlans().get(0));
-
-    PlanRecommendation planRecommendation =
-        new PlanRecommendation(
-            IDGenerator.generateId(),
-            user.getId(),
-            currentGoal.getId(),
-            targetPlan.getId(),
-            response.getOutput());
-
-    planRecommendationRepository.save(planRecommendation);
-
-    return planRecommendation;
+    Goal currentGoal = getCurrentProgressGoal(user);
+    GoalRecommendationData data = dataCollector.collectData(user, currentGoal);
+    PlanRecommendation recommendation = recommendationService.generateRecommendation(user, currentGoal, data);
+    
+    planRecommendationRepository.save(recommendation);
+    
+    return recommendation;
   }
 
-  private String calculateRemainingTime(Goal goal) {
-    LocalDate today = LocalDate.now();
-    LocalDate dueDate = goal.getDuration().endDate();
-
-    if (dueDate == null) {
-      return "기간 정보 없음";
-    }
-
-    if (today.isAfter(dueDate)) {
-      return "목표 기간 종료";
-    }
-
-    Period period = Period.between(today, dueDate);
-    int months = period.getMonths();
-    int days = period.getDays();
-
-    if (months > 0 && days > 0) {
-      return String.format("%d개월 %d일 남음", months, days);
-    } else if (months > 0) {
-      return String.format("%d개월 남음", months);
-    } else if (days > 0) {
-      return String.format("%d일 남음", days);
-    } else {
-      return "오늘 마감";
-    }
+  private Goal getCurrentProgressGoal(User user) {
+    return getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS).stream()
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException("진행중인 목표가 없습니다."));
   }
 }


### PR DESCRIPTION
- 데이터 수집 및 조언 생성을 처리하기 위해 MentorAdvisionDataCollector와 MentorAdvisionService를 추가했습니다.
- 목표 추천 데이터 처리를 위한 목표 추천 데이터 수집기 및 목표 추천 서비스를 도입했습니다.
- 데이터 처리 개선을 위해 새로운 서비스를 활용하기 위해 GenerationMentorAdvisoryUseCase와 GenerateGoalRecommendationUseCase가 업데이트되었습니다.
- 가치 객체인 멘토어드바이스데이터와 골추천데이터를 생성하여 조언 생성에 필요한 데이터를 캡슐화합니다.
