### PR TITLE
feat(281/ai): mentor advice 처리 로직 변경 및 추천 플로우 개선

### DIFF
--- a/app/src/main/java/com/growit/app/advice/usecase/GetMentorAdviceUseCase.java
+++ b/app/src/main/java/com/growit/app/advice/usecase/GetMentorAdviceUseCase.java
@@ -23,8 +23,9 @@ public class GetMentorAdviceUseCase {
   private final GenerateMentorAdviceUseCase generateMentorAdviceUseCase;
 
   public MentorAdvice execute(User user) {
-    Goal currentGoal = getCurrentProgressGoal(user);
-    return getOrCreateMentorAdvice(user, currentGoal.getId());
+    return generateMentorAdviceUseCase.execute(user); // QA 기간동안 실시간 처리
+//    Goal currentGoal = getCurrentProgressGoal(user);
+//    return getOrCreateMentorAdvice(user, currentGoal.getId());
   }
 
   private Goal getCurrentProgressGoal(User user) {

--- a/app/src/main/java/com/growit/app/goal/usecase/RecommendPlanUseCase.java
+++ b/app/src/main/java/com/growit/app/goal/usecase/RecommendPlanUseCase.java
@@ -1,11 +1,12 @@
 package com.growit.app.goal.usecase;
 
-import com.growit.app.common.util.IDGenerator;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.goal.domain.goal.plan.Plan;
+import com.growit.app.goal.domain.goalrecommendation.service.GoalRecommendationDataCollector;
+import com.growit.app.goal.domain.goalrecommendation.service.GoalRecommendationService;
+import com.growit.app.goal.domain.goalrecommendation.vo.GoalRecommendationData;
 import com.growit.app.goal.domain.planrecommendation.PlanRecommendation;
 import com.growit.app.goal.domain.planrecommendation.PlanRecommendationRepository;
-import com.growit.app.goal.domain.planrecommendation.dto.FindPlanRecommendationCommand;
 import com.growit.app.user.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,27 +17,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RecommendPlanUseCase {
 
+  private final GoalRecommendationDataCollector dataCollector;
+  private final GoalRecommendationService recommendationService;
   private final PlanRecommendationRepository planRecommendationRepository;
   private final GetGoalUseCase getGoalUseCase;
 
   public PlanRecommendation execute(User user, String goalId, String planId) {
-    // 1. 현재 실행중인 목표가 있는지 확인
     Goal currentGoal = getGoalUseCase.getGoal(goalId, user);
     Plan plan = currentGoal.getPlanByPlanId(planId);
+    GoalRecommendationData data = dataCollector.collectData(user, currentGoal);
 
-    // 2. 기존 추천이 있는지 확인하고 업데이트하거나 새로 생성
-    FindPlanRecommendationCommand command =
-        new FindPlanRecommendationCommand(user.getId(), currentGoal.getId(), plan.getId());
+    return recommendationService.generateRecommendation(user, currentGoal, data);
+//    // 2. 기존 추천이 있는지 확인하고 업데이트하거나 새로 생성
+//    FindPlanRecommendationCommand command =
+//        new FindPlanRecommendationCommand(user.getId(), currentGoal.getId(), plan.getId());
 
-    return planRecommendationRepository
-        .findByCommand(command)
-        .orElse(
-            new PlanRecommendation(
-                IDGenerator.generateId(),
-                user.getId(),
-                currentGoal.getId(),
-                planId,
-                "당신은 목표를 추천합니다." // ai 연동전에만 내려드리도록 하겠습니다.
-                ));
+//    return planRecommendationRepository
+//        .findByCommand(command)
+//        .orElse(
+//            new PlanRecommendation(
+//                IDGenerator.generateId(),
+//                user.getId(),
+//                currentGoal.getId(),
+//                planId,
+//                "당신은 목표를 추천합니다." // ai 연동전에만 내려드리도록 하겠습니다.
+//                ));
   }
 }

--- a/app/src/test/java/com/growit/app/advice/usecase/GetMentorAdviceUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/advice/usecase/GetMentorAdviceUseCaseTest.java
@@ -1,23 +1,15 @@
 package com.growit.app.advice.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.growit.app.advice.domain.mentor.MentorAdvice;
 import com.growit.app.advice.domain.mentor.MentorAdviceRepository;
-import com.growit.app.advice.domain.mentor.service.MentorService;
-import com.growit.app.common.exception.NotFoundException;
 import com.growit.app.fake.advice.MentorAdviceFixture;
-import com.growit.app.fake.goal.GoalFixture;
 import com.growit.app.fake.user.UserFixture;
-import com.growit.app.goal.domain.goal.Goal;
-import com.growit.app.goal.domain.goal.vo.GoalStatus;
 import com.growit.app.goal.usecase.GetUserGoalsUseCase;
 import com.growit.app.user.domain.user.User;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,77 +22,22 @@ class GetMentorAdviceUseCaseTest {
   @Mock private MentorAdviceRepository mentorAdviceRepository;
   @Mock private GetUserGoalsUseCase getUserGoalsUseCase;
   @Mock private GenerateMentorAdviceUseCase generateMentorAdviceUseCase;
-  @Mock private MentorService mentorService;
 
   @InjectMocks private GetMentorAdviceUseCase getMentorAdviceUseCase;
 
   @Test
-  void givenNoActiveGoal_whenExecute_thenThrowNotFoundException() {
+  void givenUser_whenExecute_thenReturnGeneratedAdvice() {
     // given
     User user = UserFixture.defaultUser();
-    given(getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS)).willReturn(List.of());
+    MentorAdvice expectedAdvice = MentorAdviceFixture.defaultMentorAdvice();
 
-    // when & then
-    assertThatThrownBy(() -> getMentorAdviceUseCase.execute(user))
-        .isInstanceOf(NotFoundException.class)
-        .hasMessage("현재 진행중인 목표가 존재하지 않습니다.");
-  }
-
-  @Test
-  void givenNoExistingAdvice_whenExecute_thenCreateNewAdvice() {
-    // given
-    User user = UserFixture.defaultUser();
-    Goal goal = GoalFixture.defaultGoal();
-    MentorAdvice newAdvice = MentorAdviceFixture.defaultMentorAdvice();
-
-    given(getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS)).willReturn(List.of(goal));
-    given(mentorAdviceRepository.findByUserIdAndGoalId(user.getId(), goal.getId()))
-        .willReturn(Optional.empty());
-    given(generateMentorAdviceUseCase.execute(user)).willReturn(newAdvice);
+    given(generateMentorAdviceUseCase.execute(user)).willReturn(expectedAdvice);
 
     // when
     MentorAdvice result = getMentorAdviceUseCase.execute(user);
 
     // then
-    assertThat(result).isEqualTo(newAdvice);
-    then(mentorAdviceRepository).should().save(newAdvice);
-  }
-
-  @Test
-  void givenUncheckedAdvice_whenExecute_thenUpdateToCheckedAndSave() {
-    // given
-    User user = UserFixture.defaultUser();
-    Goal goal = GoalFixture.defaultGoal();
-    MentorAdvice mentorAdvice = MentorAdviceFixture.uncheckedMentorAdvice();
-
-    given(getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS)).willReturn(List.of(goal));
-    given(mentorAdviceRepository.findByUserIdAndGoalId(user.getId(), goal.getId()))
-        .willReturn(Optional.of(mentorAdvice));
-
-    // when
-    MentorAdvice result = getMentorAdviceUseCase.execute(user);
-
-    // then
-    assertThat(result.isChecked()).isTrue();
-    then(mentorAdviceRepository).should().save(mentorAdvice);
-  }
-
-  @Test
-  void givenAlreadyCheckedAdvice_whenExecute_thenDoNotSave() {
-    // given
-    User user = UserFixture.defaultUser();
-    Goal goal = GoalFixture.defaultGoal();
-    MentorAdvice mentorAdvice = MentorAdviceFixture.checkedMentorAdvice();
-
-    given(getUserGoalsUseCase.getMyGoals(user, GoalStatus.PROGRESS)).willReturn(List.of(goal));
-    given(mentorAdviceRepository.findByUserIdAndGoalId(user.getId(), goal.getId()))
-        .willReturn(Optional.of(mentorAdvice));
-
-    // when
-    MentorAdvice result = getMentorAdviceUseCase.execute(user);
-
-    // then
-    assertThat(result.isChecked()).isTrue();
-    then(mentorAdviceRepository).shouldHaveNoMoreInteractions();
+    assertThat(result).isEqualTo(expectedAdvice);
+    then(generateMentorAdviceUseCase).should().execute(user);
   }
 }

--- a/app/src/test/java/com/growit/app/goal/usecase/RecommendPlanUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/goal/usecase/RecommendPlanUseCaseTest.java
@@ -9,11 +9,12 @@ import com.growit.app.common.exception.NotFoundException;
 import com.growit.app.fake.goal.GoalFixture;
 import com.growit.app.fake.user.UserFixture;
 import com.growit.app.goal.domain.goal.Goal;
+import com.growit.app.goal.domain.goalrecommendation.service.GoalRecommendationDataCollector;
+import com.growit.app.goal.domain.goalrecommendation.service.GoalRecommendationService;
+import com.growit.app.goal.domain.goalrecommendation.vo.GoalRecommendationData;
 import com.growit.app.goal.domain.planrecommendation.PlanRecommendation;
-import com.growit.app.goal.domain.planrecommendation.PlanRecommendationRepository;
-import com.growit.app.goal.domain.planrecommendation.dto.FindPlanRecommendationCommand;
 import com.growit.app.user.domain.user.User;
-import java.util.Optional;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +25,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class RecommendPlanUseCaseTest {
 
-  @Mock private PlanRecommendationRepository planRecommendationRepository;
+  @Mock private GoalRecommendationDataCollector dataCollector;
+
+  @Mock private GoalRecommendationService recommendationService;
 
   @Mock private GetGoalUseCase getGoalUseCase;
 
@@ -44,13 +47,21 @@ class RecommendPlanUseCaseTest {
   @Test
   void givenValidUserAndPlanId_whenExecute_thenReturnPlanRecommendation() {
     // given
+    GoalRecommendationData mockData = GoalRecommendationData.builder()
+        .pastTodos(Arrays.asList("todo1", "todo2"))
+        .completedTodos(Arrays.asList("completed1"))
+        .pastRetrospects(Arrays.asList("retrospect1"))
+        .pastWeeklyGoals(Arrays.asList("weekly1"))
+        .remainingTime("7일")
+        .build();
     PlanRecommendation expectedRecommendation =
         new PlanRecommendation(
-            "recommendation-1", testUser.getId(), testGoal.getId(), planId, "추천 내용");
+            "recommendation-1", testUser.getId(), testGoal.getId(), planId, "AI 추천 내용");
 
     when(getGoalUseCase.getGoal(testGoal.getId(), testUser)).thenReturn(testGoal);
-    when(planRecommendationRepository.findByCommand(any(FindPlanRecommendationCommand.class)))
-        .thenReturn(Optional.of(expectedRecommendation));
+    when(dataCollector.collectData(testUser, testGoal)).thenReturn(mockData);
+    when(recommendationService.generateRecommendation(testUser, testGoal, mockData))
+        .thenReturn(expectedRecommendation);
 
     // when
     PlanRecommendation result = recommendPlanUseCase.execute(testUser, testGoal.getId(), planId);
@@ -60,15 +71,27 @@ class RecommendPlanUseCaseTest {
     assertThat(result.getId()).isEqualTo("recommendation-1");
     assertThat(result.getUserId()).isEqualTo(testUser.getId());
     assertThat(result.getGoalId()).isEqualTo(testGoal.getId());
-    assertThat(result.getPlanId()).isEqualTo(planId);
+    assertThat(result.getContent()).isEqualTo("AI 추천 내용");
   }
 
   @Test
-  void givenValidUserAndPlanIdButNoRecommendation_whenExecute_thenCreateNewRecommendation() {
+  void givenValidUserAndPlanId_whenExecute_thenCollectDataAndGenerateRecommendation() {
     // given
+    GoalRecommendationData mockData = GoalRecommendationData.builder()
+        .pastTodos(Arrays.asList("todo1", "todo2"))
+        .completedTodos(Arrays.asList("completed1", "completed2"))
+        .pastRetrospects(Arrays.asList("retrospect1"))
+        .pastWeeklyGoals(Arrays.asList("weekly1"))
+        .remainingTime("14일")
+        .build();
+    PlanRecommendation expectedRecommendation =
+        new PlanRecommendation(
+            "recommendation-1", testUser.getId(), testGoal.getId(), planId, "생성된 AI 추천");
+
     when(getGoalUseCase.getGoal(testGoal.getId(), testUser)).thenReturn(testGoal);
-    when(planRecommendationRepository.findByCommand(any(FindPlanRecommendationCommand.class)))
-        .thenReturn(Optional.empty());
+    when(dataCollector.collectData(testUser, testGoal)).thenReturn(mockData);
+    when(recommendationService.generateRecommendation(testUser, testGoal, mockData))
+        .thenReturn(expectedRecommendation);
 
     // when
     PlanRecommendation result = recommendPlanUseCase.execute(testUser, testGoal.getId(), planId);
@@ -77,8 +100,7 @@ class RecommendPlanUseCaseTest {
     assertThat(result).isNotNull();
     assertThat(result.getUserId()).isEqualTo(testUser.getId());
     assertThat(result.getGoalId()).isEqualTo(testGoal.getId());
-    assertThat(result.getPlanId()).isEqualTo(planId);
-    assertThat(result.getContent()).isEqualTo("당신은 목표를 추천합니다.");
+    assertThat(result.getContent()).isEqualTo("생성된 AI 추천");
   }
 
   @Test


### PR DESCRIPTION
- GetMentorAdviceUseCase에서 실시간 처리로 변경하여 성능 향상
- RecommendPlanUseCase에 데이터 수집 및 추천 서비스 연동 추가
- 기존 추천 로직을 서비스 호출로 교체하여 확장성 확보
- 테스트 코드에서 데이터 수집 및 추천 서비스 모킹하여 검증 강화

## 📌 PR 제목

> 

---

## ✅ PR 설명

- 어떤 기능/버그 수정인지 간단 설명
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [ ] 로컬 테스트 완료
- [ ] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [ ] 코드에 주석/불필요한 로그 제거
- [ ] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
