### PR TITLE
feat: UserPromotionMapEntity에서 사용 기록 관련 코드 제거 (issue #281)

### DIFF
--- a/app/src/main/java/com/growit/app/user/domain/promotion/Promotion.java
+++ b/app/src/main/java/com/growit/app/user/domain/promotion/Promotion.java
@@ -33,7 +33,7 @@ public class Promotion {
   }
 
   public boolean isValid() {
-    return isActive && !isExpired() && !isUsed;
+    return isActive && !isExpired();
   }
 
   public void deactivate() {

--- a/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/source/entity/UserPromotionMapEntity.java
+++ b/app/src/main/java/com/growit/app/user/infrastructure/persistence/user/source/entity/UserPromotionMapEntity.java
@@ -3,7 +3,6 @@ package com.growit.app.user.infrastructure.persistence.user.source.entity;
 import com.growit.app.common.entity.BaseEntity;
 import com.growit.app.user.infrastructure.persistence.promotion.source.entity.PromotionEntity;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -22,23 +21,7 @@ public class UserPromotionMapEntity extends BaseEntity {
   @JoinColumn(name = "promotion_id", referencedColumnName = "uid", nullable = false)
   private PromotionEntity promotion;
 
-  @Column(name = "used_at")
-  private LocalDateTime usedAt;
-
-  @Column(name = "is_used", nullable = false)
-  private Boolean isUsed;
-
   public static UserPromotionMapEntity create(UserEntity user, PromotionEntity promotion) {
-    return UserPromotionMapEntity.builder()
-        .user(user)
-        .promotion(promotion)
-        .usedAt(LocalDateTime.now())
-        .isUsed(false)
-        .build();
-  }
-
-  public void markAsUsed() {
-    this.isUsed = true;
-    this.usedAt = LocalDateTime.now();
+    return UserPromotionMapEntity.builder().user(user).promotion(promotion).build();
   }
 }

--- a/app/src/main/resources/messages.properties
+++ b/app/src/main/resources/messages.properties
@@ -114,3 +114,4 @@ validation.invitation.phone.pattern=전화번호 형식이 올바르지 않습�
 
 error.server=서버에 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
 error.promotion.code-not-found=프로모션 코드가 올바르지 않습니다.
+error.promotion.code-invalid=프로모션 코드가 올바르지 않습니다.

--- a/app/src/test/java/com/growit/app/user/usecase/RegisterPromotionUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/user/usecase/RegisterPromotionUseCaseTest.java
@@ -48,8 +48,7 @@ class RegisterPromotionUseCaseTest {
   }
 
   @Test
-  void
-      givenInvalidPromotionCode_whenRegisterPromotion_thenThrowPromotionCodeNotFoundException() {
+  void givenInvalidPromotionCode_whenRegisterPromotion_thenThrowPromotionCodeNotFoundException() {
     // given
     User user = UserFixture.defaultUser();
     String invalidCode = "INVALID_CODE";

--- a/app/src/test/java/com/growit/app/user/usecase/RegisterPromotionUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/user/usecase/RegisterPromotionUseCaseTest.java
@@ -29,7 +29,7 @@ class RegisterPromotionUseCaseTest {
   @InjectMocks private RegisterPromotionUseCase registerPromotionUseCase;
 
   @Test
-  void given_ValidPromotionCode_when_RegisterPromotion_then_Success() {
+  void givenValidPromotionCode_whenRegisterPromotion_thenSuccess() {
     // given
     User user = UserFixture.defaultUser();
     String promotionCode = "WELCOME2024";
@@ -49,7 +49,7 @@ class RegisterPromotionUseCaseTest {
 
   @Test
   void
-      given_InvalidPromotionCode_when_RegisterPromotion_then_ThrowPromotionCodeNotFoundException() {
+      givenInvalidPromotionCode_whenRegisterPromotion_thenThrowPromotionCodeNotFoundException() {
     // given
     User user = UserFixture.defaultUser();
     String invalidCode = "INVALID_CODE";
@@ -63,7 +63,7 @@ class RegisterPromotionUseCaseTest {
   }
 
   @Test
-  void given_ExpiredPromotion_when_RegisterPromotion_then_ThrowPromotionCodeInvalidException() {
+  void givenExpiredPromotion_whenRegisterPromotion_thenThrowPromotionCodeInvalidException() {
     // given
     User user = UserFixture.defaultUser();
     String promotionCode = "EXPIRED_PROMO";
@@ -79,7 +79,7 @@ class RegisterPromotionUseCaseTest {
 
   @Test
   void
-      given_UserWithActivePromotion_when_RegisterPromotion_then_ThrowPromotionCodeAlreadyExistsException() {
+      givenUserWithActivePromotion_whenRegisterPromotion_thenThrowPromotionCodeAlreadyExistsException() {
     // given
     User user = UserFixture.userWithPromotion();
     String promotionCode = "NEW_PROMO";
@@ -91,20 +91,5 @@ class RegisterPromotionUseCaseTest {
     assertThatThrownBy(() -> registerPromotionUseCase.execute(user, promotionCode))
         .isInstanceOf(BadRequestException.class)
         .hasMessage(PROMOTION_CODE_ALREADY_EXISTS.getCode());
-  }
-
-  @Test
-  void given_UsedPromotionCode_when_RegisterPromotion_then_ThrowPromotionCodeInvalidException() {
-    // given
-    User user = UserFixture.defaultUser();
-    String promotionCode = "USED_PROMO";
-    Promotion usedPromotion = PromotionFixture.usedPromotionWithCode(promotionCode);
-
-    given(promotionRepository.findByCode(promotionCode)).willReturn(Optional.of(usedPromotion));
-
-    // when & then
-    assertThatThrownBy(() -> registerPromotionUseCase.execute(user, promotionCode))
-        .isInstanceOf(BadRequestException.class)
-        .hasMessage(PROMOTION_CODE_INVALID.getCode());
   }
 }


### PR DESCRIPTION
- usedAt, isUsed 필드 제거로 엔티티 단순화
- create 메서드 수정하여 사용 기록 없이 생성하도록 변경
- markAsUsed 메서드 제거하여 상태 변경 기능 삭제
- Promotion.java에서 isValid() 조건 수정하여 사용 여부 체크 로직 간소화

## 📌 PR 제목

> promotion 코드 조건 수정

---

## ✅ PR 설명

- 어떤 기능/버그 수정인지 간단 설명
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [ ] 로컬 테스트 완료
- [ ] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [ ] 코드에 주석/불필요한 로그 제거
- [ ] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
