### PR TITLE
fix: 단일 투두 수정 시 루틴 연결 유지하도록 변경 (bug/369/todo)

### DIFF
--- a/app/src/main/java/com/growit/app/todo/domain/ToDo.java
+++ b/app/src/main/java/com/growit/app/todo/domain/ToDo.java
@@ -50,6 +50,15 @@ public class ToDo {
     this.routine = command.routine();
   }
 
+  public void updateContentOnly(UpdateToDoCommand command) {
+    // 루틴 정보는 유지하고 내용만 변경
+    this.date = command.date();
+    this.goalId = command.goalId();
+    this.content = command.content();
+    this.isImportant = command.isImportant();
+    // routine은 변경하지 않음
+  }
+
   public void removeRoutine() {
     this.routine = null;
   }

--- a/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
+++ b/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
@@ -187,9 +187,8 @@ public class RoutineServiceImpl implements RoutineService {
   }
 
   private ToDoResult updateSingleToDo(ToDo existingToDo, UpdateToDoCommand command) {
-    // 단일 투두 수정: 해당 투두만 수정하고 루틴 연결을 제거하여 독립적으로 만듦
-    existingToDo.updateBy(command);
-    existingToDo.removeRoutine(); // 루틴 연결 제거하여 단일 투두로 변경
+    // 단일 투두 수정: 해당 투두만 내용 변경하고 반복 연결은 유지
+    existingToDo.updateContentOnly(command);
     toDoRepository.saveToDo(existingToDo);
     return new ToDoResult(existingToDo.getId());
   }


### PR DESCRIPTION
## 📌 PR 제목

> fix: 투두 수정 시 반복 삭제 이슈

---

## ✅ PR 설명

- 어떤 기능/버그 수정인지 간단 설명
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
