### PR TITLE
feat: home matrix view - category enum for todos

### DIFF
--- a/app/src/main/java/com/growit/app/todo/controller/ToDoController.java
+++ b/app/src/main/java/com/growit/app/todo/controller/ToDoController.java
@@ -75,10 +75,12 @@ public class ToDoController {
 
   @GetMapping(params = "date")
   public ResponseEntity<ApiResponse<List<ToDoWithGoalResponse>>> getTodosByDate(
-      @AuthenticationPrincipal User user, @RequestParam String date) {
+      @AuthenticationPrincipal User user,
+      @RequestParam String date,
+      @RequestParam(required = false) String category) {
     List<ToDoWithGoalDto> todoList =
         getTodosWithGoalByDateUseCase.execute(
-            toDoRequestMapper.toGetDateQueryFilter(user.getId(), date));
+            toDoRequestMapper.toGetDateQueryFilter(user.getId(), date, category));
     return ResponseEntity.ok(
         ApiResponse.success(toDoResponseMapper.toToDoWithGoalResponseList(todoList)));
   }

--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/CompletedStatusChangeRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/CompletedStatusChangeRequest.java
@@ -1,6 +1,7 @@
 package com.growit.app.todo.controller.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.growit.app.todo.domain.TodoCategory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,5 @@ public class CompletedStatusChangeRequest {
   @JsonProperty("isCompleted")
   private Boolean completed;
 
-  @JsonProperty("isImportant")
-  private Boolean important; // Use Boolean wrapper to allow null values
+  private TodoCategory category; // nullable
 }

--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
@@ -1,7 +1,7 @@
 package com.growit.app.todo.controller.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
+import com.growit.app.todo.domain.TodoCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -21,12 +21,7 @@ public class CreateToDoRequest {
   @Size(min = 1, max = 30, message = "{validation.todo.content.size}")
   private String content;
 
-  private boolean isImportant;
+  private TodoCategory category;
 
   private RoutineDto routine;
-
-  @JsonProperty("isImportant")
-  public boolean isImportant() {
-    return isImportant;
-  }
 }

--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
@@ -1,7 +1,7 @@
 package com.growit.app.todo.controller.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -22,8 +22,7 @@ public class UpdateToDoRequest {
   @Size(min = 1, max = 30, message = "{validation.todo.content.size}")
   private String content;
 
-  @JsonProperty("isImportant")
-  private Boolean important; // Use Boolean wrapper to allow null values
+  private TodoCategory category; // nullable
 
   private RoutineDto routine; // nullable
   private RoutineUpdateType routineUpdateType; // nullable

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
@@ -1,6 +1,7 @@
 package com.growit.app.todo.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.growit.app.todo.domain.TodoCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +15,7 @@ public class TodoDto {
   private String date;
   private String content;
 
-  @JsonProperty("isImportant")
-  private boolean important;
+  private TodoCategory category;
 
   @JsonProperty("isCompleted")
   private boolean completed;

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/WeeklyTodosResponse.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/WeeklyTodosResponse.java
@@ -2,6 +2,7 @@ package com.growit.app.todo.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.Routine;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +18,7 @@ public class WeeklyTodosResponse {
   @JsonProperty("isCompleted")
   private boolean completed;
 
-  @JsonProperty("isImportant")
-  private boolean important;
+  private TodoCategory category;
 
   private Routine routine;
 
@@ -29,7 +29,7 @@ public class WeeklyTodosResponse {
         .date(todo.getDate().toString())
         .content(todo.getContent())
         .completed(todo.isCompleted())
-        .important(todo.isImportant())
+        .category(todo.getCategory())
         .routine(todo.getRoutine())
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
@@ -4,6 +4,7 @@ import com.growit.app.todo.controller.dto.request.CompletedStatusChangeRequest;
 import com.growit.app.todo.controller.dto.request.CreateToDoRequest;
 import com.growit.app.todo.controller.dto.request.UpdateToDoRequest;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.*;
 import com.growit.app.todo.domain.vo.*;
 import java.time.LocalDate;
@@ -18,7 +19,7 @@ public class ToDoRequestMapper {
         request.getGoalId(),
         request.getContent(),
         request.getDate(),
-        request.isImportant(),
+        request.getCategory(),
         toDomainRoutine(request.getRoutine()));
   }
 
@@ -29,7 +30,7 @@ public class ToDoRequestMapper {
         request.getGoalId(),
         request.getContent(),
         request.getDate(),
-        request.getImportant() != null ? request.getImportant() : false,
+        request.getCategory(),
         toDomainRoutine(request.getRoutine()),
         request.getRoutine() != null && request.getRoutineUpdateType() == null
             ? RoutineUpdateType.ALL
@@ -39,7 +40,7 @@ public class ToDoRequestMapper {
   public CompletedStatusChangeCommand toCompletedStatusChangeCommand(
       String id, String userId, CompletedStatusChangeRequest request) {
     return new CompletedStatusChangeCommand(
-        id, userId, request.getCompleted(), request.getImportant());
+        id, userId, request.getCompleted(), request.getCategory());
   }
 
   public DeleteToDoCommand toDeleteCommand(String id, String userId) {
@@ -62,7 +63,25 @@ public class ToDoRequestMapper {
     } catch (Exception e) {
       today = LocalDate.now();
     }
-    return new GetDateQueryFilter(userId, today);
+    return new GetDateQueryFilter(userId, today, null);
+  }
+
+  public GetDateQueryFilter toGetDateQueryFilter(String userId, String date, String category) {
+    LocalDate today;
+    try {
+      today = LocalDate.parse(date);
+    } catch (Exception e) {
+      today = LocalDate.now();
+    }
+    TodoCategory todoCategory = null;
+    if (category != null && !category.isBlank()) {
+      try {
+        todoCategory = TodoCategory.valueOf(category.toUpperCase());
+      } catch (IllegalArgumentException ignored) {
+        // invalid category value, treat as no filter
+      }
+    }
+    return new GetDateQueryFilter(userId, today, todoCategory);
   }
 
   public GetDateRangeQueryFilter toGetDateRangeQueryFilter(

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
@@ -26,7 +26,7 @@ public class ToDoResponseMapper {
         .goalId(todo.getGoalId())
         .date(todo.getDate().toString())
         .content(todo.getContent())
-        .important(todo.isImportant())
+        .category(todo.getCategory())
         .completed(todo.isCompleted())
         .routine(toRoutineDto(todo.getRoutine()))
         .build();

--- a/app/src/main/java/com/growit/app/todo/domain/ToDo.java
+++ b/app/src/main/java/com/growit/app/todo/domain/ToDo.java
@@ -23,8 +23,7 @@ public class ToDo {
   private boolean isCompleted;
   private boolean isDeleted;
 
-  @JsonProperty("isImportant")
-  private boolean isImportant;
+  @Builder.Default private TodoCategory category = TodoCategory.NOW;
 
   private Routine routine;
 
@@ -37,7 +36,7 @@ public class ToDo {
         .date(command.date())
         .isCompleted(false)
         .isDeleted(false)
-        .isImportant(command.isImportant())
+        .category(command.category() != null ? command.category() : TodoCategory.NOW)
         .routine(command.routine())
         .build();
   }
@@ -46,7 +45,7 @@ public class ToDo {
     this.date = command.date();
     this.goalId = command.goalId();
     this.content = command.content();
-    this.isImportant = command.isImportant();
+    this.category = command.category() != null ? command.category() : this.category;
     this.routine = command.routine();
   }
 
@@ -55,7 +54,7 @@ public class ToDo {
     this.date = command.date();
     this.goalId = command.goalId();
     this.content = command.content();
-    this.isImportant = command.isImportant();
+    this.category = command.category() != null ? command.category() : this.category;
     // routine은 변경하지 않음
   }
 
@@ -67,8 +66,8 @@ public class ToDo {
     this.isCompleted = isCompleted;
   }
 
-  public void updateIsImportant(boolean isImportant) {
-    this.isImportant = isImportant;
+  public void updateCategory(TodoCategory category) {
+    this.category = category;
   }
 
   public void deleted() {
@@ -85,8 +84,7 @@ public class ToDo {
     return isDeleted;
   }
 
-  @JsonProperty("isImportant")
-  public boolean isImportant() {
-    return isImportant;
+  public TodoCategory getCategory() {
+    return category;
   }
 }

--- a/app/src/main/java/com/growit/app/todo/domain/TodoCategory.java
+++ b/app/src/main/java/com/growit/app/todo/domain/TodoCategory.java
@@ -1,0 +1,8 @@
+package com.growit.app.todo.domain;
+
+public enum TodoCategory {
+  NOW, // 긴급O + 중요O (지금/빨리 끝내기)
+  STEADY, // 긴급X + 중요O (꾸준히/천천히 끝내기)
+  SKIP, // 긴급O + 중요X (넘겨도)
+  DELETE // 긴급X + 중요X (지워도)
+}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/CompletedStatusChangeCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/CompletedStatusChangeCommand.java
@@ -1,4 +1,6 @@
 package com.growit.app.todo.domain.dto;
 
+import com.growit.app.todo.domain.TodoCategory;
+
 public record CompletedStatusChangeCommand(
-    String id, String userId, Boolean completed, Boolean important) {}
+    String id, String userId, Boolean completed, TodoCategory category) {}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
@@ -1,5 +1,6 @@
 package com.growit.app.todo.domain.dto;
 
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.Routine;
 import java.time.LocalDate;
 
@@ -8,5 +9,5 @@ public record CreateToDoCommand(
     String goalId,
     String content,
     LocalDate date,
-    boolean isImportant,
+    TodoCategory category,
     Routine routine) {}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/GetDateQueryFilter.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/GetDateQueryFilter.java
@@ -1,5 +1,10 @@
 package com.growit.app.todo.domain.dto;
 
+import com.growit.app.todo.domain.TodoCategory;
 import java.time.LocalDate;
 
-public record GetDateQueryFilter(String userId, LocalDate date) {}
+public record GetDateQueryFilter(String userId, LocalDate date, TodoCategory category) {
+  public GetDateQueryFilter(String userId, LocalDate date) {
+    this(userId, date, null);
+  }
+}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
@@ -1,5 +1,6 @@
 package com.growit.app.todo.domain.dto;
 
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
 import java.time.LocalDate;
@@ -10,6 +11,6 @@ public record UpdateToDoCommand(
     String goalId,
     String content,
     LocalDate date,
-    boolean isImportant,
+    TodoCategory category,
     Routine routine,
     RoutineUpdateType routineUpdateType) {}

--- a/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
+++ b/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
@@ -1,8 +1,8 @@
 package com.growit.app.todo.domain.service;
 
 import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.ToDoRepository;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.DeleteToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;

--- a/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
+++ b/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
@@ -1,6 +1,7 @@
 package com.growit.app.todo.domain.service;
 
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.ToDoRepository;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.DeleteToDoCommand;
@@ -28,7 +29,7 @@ public class RoutineServiceImpl implements RoutineService {
         command.userId(),
         command.goalId(),
         command.content(),
-        command.isImportant(),
+        command.category(),
         command.date(),
         command.routine().getDuration().getStartDate(),
         command.routine().getDuration().getEndDate());
@@ -268,7 +269,7 @@ public class RoutineServiceImpl implements RoutineService {
               command.goalId(),
               command.content(),
               command.date(),
-              command.isImportant(),
+              command.category(),
               command.routine());
       return createRoutineToDos(createCommand);
     } else {
@@ -278,7 +279,7 @@ public class RoutineServiceImpl implements RoutineService {
               command.goalId(),
               command.content(),
               command.date(),
-              command.isImportant(),
+              command.category(),
               null);
       ToDo newToDo = ToDo.from(createCommand);
       toDoRepository.saveToDo(newToDo);
@@ -292,7 +293,7 @@ public class RoutineServiceImpl implements RoutineService {
         command.userId(),
         command.goalId(),
         command.content(),
-        command.isImportant(),
+        command.category(),
         command.date(),
         fromDate,
         command.routine().getDuration().getEndDate());
@@ -303,7 +304,7 @@ public class RoutineServiceImpl implements RoutineService {
       String userId,
       String goalId,
       String content,
-      boolean isImportant,
+      TodoCategory category,
       LocalDate baseDate,
       LocalDate startDate,
       LocalDate endDate) {
@@ -315,7 +316,7 @@ public class RoutineServiceImpl implements RoutineService {
     String firstToDoId = null;
     for (LocalDate date : dates) {
       CreateToDoCommand routineCommand =
-          new CreateToDoCommand(userId, goalId, content, date, isImportant, sharedRoutine);
+          new CreateToDoCommand(userId, goalId, content, date, category, sharedRoutine);
 
       ToDo toDo = ToDo.from(routineCommand);
       toDoRepository.saveToDo(toDo);

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
@@ -39,7 +39,10 @@ public class ToDoDBMapper {
         .date(entity.getDate())
         .isCompleted(entity.isCompleted())
         .isDeleted(entity.getDeletedAt() != null)
-        .category(entity.getCategory() != null ? TodoCategory.valueOf(entity.getCategory()) : TodoCategory.NOW)
+        .category(
+            entity.getCategory() != null
+                ? TodoCategory.valueOf(entity.getCategory())
+                : TodoCategory.NOW)
         .routine(routine)
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
@@ -1,6 +1,7 @@
 package com.growit.app.todo.infrastructure.persistence.todo;
 
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineDuration;
 import com.growit.app.todo.infrastructure.persistence.todo.source.entity.RoutineEntity;
@@ -22,7 +23,7 @@ public class ToDoDBMapper {
         .content(todo.getContent())
         .date(todo.getDate())
         .isCompleted(todo.isCompleted())
-        .isImportant(todo.isImportant())
+        .category(todo.getCategory() != null ? todo.getCategory().name() : "NOW")
         .routineId(routineId)
         .build();
   }
@@ -38,7 +39,7 @@ public class ToDoDBMapper {
         .date(entity.getDate())
         .isCompleted(entity.isCompleted())
         .isDeleted(entity.getDeletedAt() != null)
-        .isImportant(entity.isImportant())
+        .category(entity.getCategory() != null ? TodoCategory.valueOf(entity.getCategory()) : TodoCategory.NOW)
         .routine(routine)
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
@@ -34,8 +34,8 @@ public class ToDoEntity extends BaseEntity {
   @Column(nullable = false, columnDefinition = "boolean default false")
   private boolean isCompleted;
 
-  @Column(nullable = false, columnDefinition = "boolean default false")
-  private boolean isImportant;
+  @Column(nullable = false, length = 10, columnDefinition = "VARCHAR(10) DEFAULT 'NOW'")
+  private String category;
 
   @Column(nullable = true)
   private String routineId;
@@ -44,7 +44,7 @@ public class ToDoEntity extends BaseEntity {
     this.date = toDo.getDate();
     this.content = toDo.getContent();
     this.isCompleted = toDo.isCompleted();
-    this.isImportant = toDo.isImportant();
+    this.category = toDo.getCategory() != null ? toDo.getCategory().name() : "NOW";
     this.goalId = toDo.getGoalId();
     if (toDo.getRoutine() != null) {
       this.routineId = toDo.getRoutine().getId();

--- a/app/src/main/java/com/growit/app/todo/usecase/CompletedStatusChangeToDoUseCase.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/CompletedStatusChangeToDoUseCase.java
@@ -23,9 +23,9 @@ public class CompletedStatusChangeToDoUseCase {
       toDo.updateIsCompleted(command.completed());
     }
 
-    // Only update importance if provided (not null)
-    if (command.important() != null) {
-      toDo.updateIsImportant(command.important());
+    // Only update category if provided (not null)
+    if (command.category() != null) {
+      toDo.updateCategory(command.category());
     }
 
     toDoRepository.saveToDo(toDo);

--- a/app/src/main/java/com/growit/app/todo/usecase/GetTodosWithGoalByDateUseCase.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/GetTodosWithGoalByDateUseCase.java
@@ -23,6 +23,12 @@ public class GetTodosWithGoalByDateUseCase {
   public List<ToDoWithGoalDto> execute(GetDateQueryFilter filter) {
     List<ToDo> todos = toDoRepository.findByUserIdAndDate(filter.userId(), filter.date());
 
+    if (filter.category() != null) {
+      todos = todos.stream()
+          .filter(todo -> filter.category().equals(todo.getCategory()))
+          .collect(Collectors.toList());
+    }
+
     return todos.stream()
         .map(
             todo -> {

--- a/app/src/main/java/com/growit/app/todo/usecase/GetTodosWithGoalByDateUseCase.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/GetTodosWithGoalByDateUseCase.java
@@ -24,9 +24,10 @@ public class GetTodosWithGoalByDateUseCase {
     List<ToDo> todos = toDoRepository.findByUserIdAndDate(filter.userId(), filter.date());
 
     if (filter.category() != null) {
-      todos = todos.stream()
-          .filter(todo -> filter.category().equals(todo.getCategory()))
-          .collect(Collectors.toList());
+      todos =
+          todos.stream()
+              .filter(todo -> filter.category().equals(todo.getCategory()))
+              .collect(Collectors.toList());
     }
 
     return todos.stream()

--- a/app/src/main/resources/db/migration/V33__replace_is_important_with_category.sql
+++ b/app/src/main/resources/db/migration/V33__replace_is_important_with_category.sql
@@ -1,0 +1,3 @@
+ALTER TABLE todos ADD COLUMN category VARCHAR(10) NOT NULL DEFAULT 'NOW';
+UPDATE todos SET category = CASE WHEN is_important = true THEN 'NOW' ELSE 'DELETE' END;
+ALTER TABLE todos DROP COLUMN is_important;

--- a/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
+++ b/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
@@ -3,6 +3,7 @@ package com.growit.app.fake.todo;
 import com.growit.app.todo.controller.dto.request.CreateToDoRequest;
 import com.growit.app.todo.controller.dto.response.WeeklyTodosResponse;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -20,7 +21,7 @@ public class ToDoFixture {
   }
 
   public static CreateToDoRequest defaultCreateToDoRequest() {
-    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", false, null);
+    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", TodoCategory.NOW, null);
   }
 
   public static Map<String, List<WeeklyTodosResponse>> weeklyTodosMapWith(
@@ -49,7 +50,7 @@ class ToDoBuilder {
   private String userId = "user-1";
   private String content = "테스트 할 일입니다.";
   private boolean isCompleted = false;
-  private boolean isImportant = false;
+  private TodoCategory category = TodoCategory.NOW;
   private LocalDate date = LocalDate.now();
 
   public ToDoBuilder id(String id) {
@@ -82,8 +83,8 @@ class ToDoBuilder {
     return this;
   }
 
-  public ToDoBuilder isImportant(boolean isImportant) {
-    this.isImportant = isImportant;
+  public ToDoBuilder category(TodoCategory category) {
+    this.category = category;
     return this;
   }
 
@@ -96,7 +97,7 @@ class ToDoBuilder {
         .date(date)
         .isCompleted(isCompleted)
         .isDeleted(false)
-        .isImportant(isImportant)
+        .category(category)
         .routine(null)
         .build();
   }

--- a/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
+++ b/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
@@ -21,7 +21,8 @@ public class ToDoFixture {
   }
 
   public static CreateToDoRequest defaultCreateToDoRequest() {
-    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", TodoCategory.NOW, null);
+    return new CreateToDoRequest(
+        "goal-1", LocalDate.now(), "할 일 예시 내용입니다.", TodoCategory.NOW, null);
   }
 
   public static Map<String, List<WeeklyTodosResponse>> weeklyTodosMapWith(

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -32,11 +32,11 @@ import com.growit.app.todo.controller.dto.response.TodoDto;
 import com.growit.app.todo.controller.mapper.ToDoRequestMapper;
 import com.growit.app.todo.controller.mapper.ToDoResponseMapper;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.CompletedStatusChangeCommand;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
-import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.RepeatType;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineDeleteType;
@@ -120,7 +120,8 @@ class ToDoControllerTest {
             Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY));
 
     CreateToDoCommand command =
-        new CreateToDoCommand("user-1", "goal-1", "할 일 내용", LocalDate.now(), TodoCategory.NOW, domainRoutine);
+        new CreateToDoCommand(
+            "user-1", "goal-1", "할 일 내용", LocalDate.now(), TodoCategory.NOW, domainRoutine);
     ToDoResult result = new ToDoResult("todo-1");
     ToDoResponse response = new ToDoResponse("todo-1");
 
@@ -218,7 +219,12 @@ class ToDoControllerTest {
             duration, RepeatType.BIWEEKLY, Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.FRIDAY));
     UpdateToDoRequest request =
         new UpdateToDoRequest(
-            "goal-1", LocalDate.now(), "수정된 할 일 내용", TodoCategory.NOW, routineDto, RoutineUpdateType.ALL);
+            "goal-1",
+            LocalDate.now(),
+            "수정된 할 일 내용",
+            TodoCategory.NOW,
+            routineDto,
+            RoutineUpdateType.ALL);
     UpdateToDoCommand command =
         new UpdateToDoCommand(
             todoId,

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -36,6 +36,7 @@ import com.growit.app.todo.domain.dto.CompletedStatusChangeCommand;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.RepeatType;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineDeleteType;
@@ -110,7 +111,7 @@ class ToDoControllerTest {
             .build();
 
     CreateToDoRequest request =
-        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", false, routineDto);
+        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", TodoCategory.NOW, routineDto);
 
     Routine domainRoutine =
         Routine.of(
@@ -119,7 +120,7 @@ class ToDoControllerTest {
             Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY));
 
     CreateToDoCommand command =
-        new CreateToDoCommand("user-1", "goal-1", "할 일 내용", LocalDate.now(), false, domainRoutine);
+        new CreateToDoCommand("user-1", "goal-1", "할 일 내용", LocalDate.now(), TodoCategory.NOW, domainRoutine);
     ToDoResult result = new ToDoResult("todo-1");
     ToDoResponse response = new ToDoResponse("todo-1");
 
@@ -155,9 +156,10 @@ class ToDoControllerTest {
                             fieldWithPath("content")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 내용 (1-30자)"),
-                            fieldWithPath("isImportant")
-                                .type(JsonFieldType.BOOLEAN)
-                                .description("중요도 여부"),
+                            fieldWithPath("category")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description("카테고리 (NOW, STEADY, SKIP, DELETE)"),
                             fieldWithPath("routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -216,7 +218,7 @@ class ToDoControllerTest {
             duration, RepeatType.BIWEEKLY, Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.FRIDAY));
     UpdateToDoRequest request =
         new UpdateToDoRequest(
-            "goal-1", LocalDate.now(), "수정된 할 일 내용", true, routineDto, RoutineUpdateType.ALL);
+            "goal-1", LocalDate.now(), "수정된 할 일 내용", TodoCategory.NOW, routineDto, RoutineUpdateType.ALL);
     UpdateToDoCommand command =
         new UpdateToDoCommand(
             todoId,
@@ -224,7 +226,7 @@ class ToDoControllerTest {
             "goal-1",
             "수정된 할 일 내용",
             LocalDate.now(),
-            true,
+            TodoCategory.NOW,
             routine,
             RoutineUpdateType.ALL);
 
@@ -265,9 +267,10 @@ class ToDoControllerTest {
                             fieldWithPath("content")
                                 .type(JsonFieldType.STRING)
                                 .description("수정할 ToDo 내용 (1-30자)"),
-                            fieldWithPath("isImportant")
-                                .type(JsonFieldType.BOOLEAN)
-                                .description("수정할 중요도 여부"),
+                            fieldWithPath("category")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description("카테고리 (NOW, STEADY, SKIP, DELETE)"),
                             fieldWithPath("routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -321,7 +324,7 @@ class ToDoControllerTest {
             "goal-123",
             LocalDate.of(2024, 1, 1),
             "Updated routine task",
-            true,
+            TodoCategory.NOW,
             routineDto,
             RoutineUpdateType.FROM_DATE);
 
@@ -332,7 +335,7 @@ class ToDoControllerTest {
             "goal-123",
             "Updated routine task",
             LocalDate.of(2024, 1, 1),
-            true,
+            TodoCategory.NOW,
             null,
             RoutineUpdateType.FROM_DATE);
     ToDoResult result = new ToDoResult("todo-123");
@@ -430,10 +433,10 @@ class ToDoControllerTest {
                                 .type(JsonFieldType.BOOLEAN)
                                 .optional()
                                 .description("완료 여부 (선택사항)"),
-                            fieldWithPath("isImportant")
-                                .type(JsonFieldType.BOOLEAN)
+                            fieldWithPath("category")
+                                .type(JsonFieldType.STRING)
                                 .optional()
-                                .description("중요도 여부 (선택사항)"))
+                                .description("카테고리 (NOW, STEADY, SKIP, DELETE) (선택사항)"))
                         .responseFields(
                             fieldWithPath("data")
                                 .type(JsonFieldType.STRING)
@@ -466,7 +469,7 @@ class ToDoControllerTest {
                         .goalId("goal-1")
                         .date("2024-01-01")
                         .content("테스트 할 일입니다.")
-                        .important(false)
+                        .category(TodoCategory.NOW)
                         .completed(false)
                         .routine(
                             RoutineDto.builder()
@@ -488,7 +491,7 @@ class ToDoControllerTest {
                         .goalId("goal-1")
                         .date("2024-01-01")
                         .content("테스트 할 일입니다.")
-                        .important(false)
+                        .category(TodoCategory.NOW)
                         .completed(false)
                         .routine(null)
                         .build())
@@ -535,9 +538,9 @@ class ToDoControllerTest {
                             fieldWithPath("data[].todo.content")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 내용"),
-                            fieldWithPath("data[].todo.isImportant")
-                                .type(JsonFieldType.BOOLEAN)
-                                .description("중요도 여부"),
+                            fieldWithPath("data[].todo.category")
+                                .type(JsonFieldType.STRING)
+                                .description("카테고리 (NOW, STEADY, SKIP, DELETE)"),
                             fieldWithPath("data[].todo.isCompleted")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("완료 여부"),
@@ -590,7 +593,7 @@ class ToDoControllerTest {
             .goalId("goal-1")
             .date("2024-01-01")
             .content("테스트 할 일입니다.")
-            .important(false)
+            .category(TodoCategory.NOW)
             .completed(false)
             .routine(null)
             .build();
@@ -634,9 +637,9 @@ class ToDoControllerTest {
                             fieldWithPath("data.isCompleted")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("완료 여부"),
-                            fieldWithPath("data.isImportant")
-                                .type(JsonFieldType.BOOLEAN)
-                                .description("중요도 여부"),
+                            fieldWithPath("data.category")
+                                .type(JsonFieldType.STRING)
+                                .description("카테고리 (NOW, STEADY, SKIP, DELETE)"),
                             fieldWithPath("data.routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()

--- a/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
+++ b/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.ToDoRepository;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;
@@ -49,7 +50,7 @@ class RoutineServiceTest {
 
     createCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Daily routine task", LocalDate.of(2024, 1, 1), true, routine);
+            "user123", "goal123", "Daily routine task", LocalDate.of(2024, 1, 1), TodoCategory.NOW, routine);
 
     updateCommand =
         new UpdateToDoCommand(
@@ -58,7 +59,7 @@ class RoutineServiceTest {
             "goal123",
             "Updated routine task",
             LocalDate.of(2024, 1, 3),
-            true,
+            TodoCategory.NOW,
             routine,
             RoutineUpdateType.FROM_DATE);
 
@@ -71,7 +72,7 @@ class RoutineServiceTest {
             .date(LocalDate.of(2024, 1, 3))
             .isCompleted(false)
             .isDeleted(false)
-            .isImportant(true)
+            .category(TodoCategory.NOW)
             .routine(routine)
             .build();
   }
@@ -123,7 +124,7 @@ class RoutineServiceTest {
             "goal123",
             "Updated all routine tasks",
             LocalDate.of(2024, 1, 3),
-            true,
+            TodoCategory.NOW,
             routine,
             RoutineUpdateType.ALL);
 
@@ -154,7 +155,7 @@ class RoutineServiceTest {
             "goal123",
             "Updated single task",
             LocalDate.of(2024, 1, 3),
-            true,
+            TodoCategory.NOW,
             null, // 루틴 제거
             RoutineUpdateType.SINGLE);
 
@@ -181,7 +182,7 @@ class RoutineServiceTest {
             "goal123",
             "Weekly routine task",
             LocalDate.of(2024, 1, 1),
-            true,
+            TodoCategory.NOW,
             weeklyRoutine);
 
     // When
@@ -201,7 +202,7 @@ class RoutineServiceTest {
         .date(date)
         .isCompleted(false)
         .isDeleted(false)
-        .isImportant(false)
+        .category(TodoCategory.NOW)
         .routine(routine)
         .build();
   }
@@ -223,7 +224,7 @@ class RoutineServiceTest {
             "goal123",
             "Weekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
-            true,
+            TodoCategory.NOW,
             weeklyRoutineWithDays);
 
     // When
@@ -252,7 +253,7 @@ class RoutineServiceTest {
             "goal123",
             "Biweekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
-            true,
+            TodoCategory.NOW,
             biweeklyRoutine);
 
     // When
@@ -280,7 +281,7 @@ class RoutineServiceTest {
             "goal123",
             "Weekly routine without specific days",
             LocalDate.of(2024, 1, 1), // 월요일
-            true,
+            TodoCategory.NOW,
             weeklyRoutineWithoutDays);
 
     // When
@@ -309,7 +310,7 @@ class RoutineServiceTest {
             "goal123",
             "Daily routine with repeatDays",
             LocalDate.of(2024, 1, 1),
-            true,
+            TodoCategory.NOW,
             dailyRoutineWithDays);
 
     // When

--- a/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
+++ b/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
@@ -8,8 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.ToDoRepository;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
@@ -50,7 +50,12 @@ class RoutineServiceTest {
 
     createCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Daily routine task", LocalDate.of(2024, 1, 1), TodoCategory.NOW, routine);
+            "user123",
+            "goal123",
+            "Daily routine task",
+            LocalDate.of(2024, 1, 1),
+            TodoCategory.NOW,
+            routine);
 
     updateCommand =
         new UpdateToDoCommand(

--- a/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
@@ -10,6 +10,7 @@ import com.growit.app.fake.goal.GoalFixture;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.goal.domain.goal.service.GoalQuery;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.ToDoRepository;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;
@@ -48,7 +49,7 @@ class CreateToDoUseCaseTest {
     goal = GoalFixture.customGoal("goal123", "Test Goal", null);
 
     simpleCommand =
-        new CreateToDoCommand("user123", "goal123", "Simple task", LocalDate.now(), false, null);
+        new CreateToDoCommand("user123", "goal123", "Simple task", LocalDate.now(), TodoCategory.NOW, null);
 
     RoutineDuration duration =
         RoutineDuration.of(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7));
@@ -57,7 +58,7 @@ class CreateToDoUseCaseTest {
 
     routineCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), true, routine);
+            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), TodoCategory.NOW, routine);
   }
 
   @Test

--- a/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
@@ -10,8 +10,8 @@ import com.growit.app.fake.goal.GoalFixture;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.goal.domain.goal.service.GoalQuery;
 import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.ToDoRepository;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.service.RoutineService;
@@ -49,7 +49,8 @@ class CreateToDoUseCaseTest {
     goal = GoalFixture.customGoal("goal123", "Test Goal", null);
 
     simpleCommand =
-        new CreateToDoCommand("user123", "goal123", "Simple task", LocalDate.now(), TodoCategory.NOW, null);
+        new CreateToDoCommand(
+            "user123", "goal123", "Simple task", LocalDate.now(), TodoCategory.NOW, null);
 
     RoutineDuration duration =
         RoutineDuration.of(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7));
@@ -58,7 +59,12 @@ class CreateToDoUseCaseTest {
 
     routineCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), TodoCategory.NOW, routine);
+            "user123",
+            "goal123",
+            "Routine task",
+            LocalDate.of(2024, 1, 1),
+            TodoCategory.NOW,
+            routine);
   }
 
   @Test

--- a/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
@@ -11,6 +11,7 @@ import com.growit.app.fake.todo.FakeToDoValidator;
 import com.growit.app.fake.todo.ToDoFixture;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.service.ToDoValidator;
@@ -51,7 +52,7 @@ class UpdateToDoUseCaseTest {
     String newContent = "수정된 내용";
     UpdateToDoCommand command =
         new UpdateToDoCommand(
-            toDo.getId(), toDo.getUserId(), toDo.getGoalId(), newContent, today, false, null, null);
+            toDo.getId(), toDo.getUserId(), toDo.getGoalId(), newContent, today, null, null, null);
 
     // When
     ToDoResult result = updateToDoUseCase.execute(command);

--- a/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
@@ -11,7 +11,6 @@ import com.growit.app.fake.todo.FakeToDoValidator;
 import com.growit.app.fake.todo.ToDoFixture;
 import com.growit.app.goal.domain.goal.Goal;
 import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.service.ToDoValidator;


### PR DESCRIPTION
## Summary
- Type: feature
- Branch: feat/DEVS-12-home-matrix-view

## Changes
- Replace `isImportant` boolean with `TodoCategory` enum (`NOW`, `STEADY`, `SKIP`, `DELETE`) for the Eisenhower matrix view
- Add DB migration `V33__replace_is_important_with_category.sql`
- Update ToDo domain, DTOs, request/response mappers, and controller to support category field
- Update tests to reflect new category-based logic

## Related PRs
- FE: https://github.com/DDD-Community/DDD-12-GROWIT-FE/pull/281

## Test plan
- [ ] Verify existing todo CRUD works with the new category field
- [ ] Check migration runs cleanly on a fresh DB
- [ ] Confirm weekly todos response includes correct category values
- [ ] Run unit tests: `ToDoControllerTest`, `RoutineServiceTest`, `CreateToDoUseCaseTest`, `UpdateToDoUseCaseTest`

Refs: DEVS-12