### PR TITLE
fix: redirect OAuth failures to FE absolute URL instead of BE /login

### DIFF
--- a/app/src/main/java/com/growit/app/common/config/oauth/OAuth2LoginFailureHandler.java
+++ b/app/src/main/java/com/growit/app/common/config/oauth/OAuth2LoginFailureHandler.java
@@ -4,6 +4,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
@@ -12,6 +14,13 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+  private static final String REDIRECT_URI_SESSION_KEY = "OAUTH2_REDIRECT_URI";
+  private static final String FAILURE_PATH = "/login?error=oauth";
+
+  private static final List<String> ALLOWED_REDIRECT_HOSTS =
+      List.of("localhost:3000", "grow-it.me", "devweb.grow-it.me");
+
   @Override
   public void onAuthenticationFailure(
       HttpServletRequest req, HttpServletResponse res, AuthenticationException exception)
@@ -19,6 +28,40 @@ public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHan
 
     log.error("OAuth2 Login Failed. Error: {}", exception.getMessage(), exception);
 
-    getRedirectStrategy().sendRedirect(req, res, "/login?error=oauth");
+    String location = resolveFailureLocation(req);
+    getRedirectStrategy().sendRedirect(req, res, location);
+  }
+
+  private String resolveFailureLocation(HttpServletRequest req) {
+    String redirectUri = getRedirectUriFromSession(req);
+    if (redirectUri == null || redirectUri.isBlank()) {
+      return FAILURE_PATH;
+    }
+    try {
+      URI uri = URI.create(redirectUri);
+      String host = uri.getHost();
+      if (host == null) {
+        return FAILURE_PATH;
+      }
+      int port = uri.getPort();
+      String hostWithPort = port != -1 ? host + ":" + port : host;
+      boolean allowed =
+          ALLOWED_REDIRECT_HOSTS.contains(host.toLowerCase())
+              || ALLOWED_REDIRECT_HOSTS.contains(hostWithPort.toLowerCase());
+      if (!allowed) {
+        return FAILURE_PATH;
+      }
+      return uri.getScheme() + "://" + hostWithPort + FAILURE_PATH;
+    } catch (IllegalArgumentException e) {
+      return FAILURE_PATH;
+    }
+  }
+
+  private String getRedirectUriFromSession(HttpServletRequest req) {
+    var session = req.getSession(false);
+    if (session != null) {
+      return (String) session.getAttribute(REDIRECT_URI_SESSION_KEY);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- `OAuth2LoginFailureHandler`가 상대경로 `/login?error=oauth`로 redirect해서 BE 도메인(`localhost:8080`)의 `/login`으로 가는 문제 수정
- BE에는 `/login` 핸들러가 없어 `{"message":"No static resource login."}` 404 응답이 노출됨
- session의 `OAUTH2_REDIRECT_URI`에서 FE origin을 추출 → `{origin}/login?error=oauth`로 redirect
- SuccessHandler와 동일한 `ALLOWED_REDIRECT_HOSTS` 검증 적용

## 증상 재현
브라우저에서 카카오 로그인 → 인증 실패 → `localhost:8080/login?error=oauth` → 404 JSON 응답이 사용자에게 노출

## 수정 후 동작
- session에 redirect-uri가 있고 allowlist에 통과하면 FE 절대 URL로 302 redirect (예: `http://localhost:3000/login?error=oauth`)
- session 없거나 allowlist 미통과 시 기존 동작(`/login?error=oauth` 상대경로)으로 fallback — 회귀 방지

## Test plan
- [ ] 로컬에서 카카오 로그인 실패 시키고 (예: 잘못된 client_secret) → FE의 `/login?error=oauth`로 정상 redirect되는지 확인
- [ ] DEV 환경에서 동일 검증
- [ ] 기존 SuccessHandler 흐름은 영향 없음 (정상 로그인 → FE OAuth callback)

## Related
- 본 PR은 OAuth 실패 시 사용자 경험 개선만 다룸. Kakao 인증 자체가 실패하는 1차 원인(예: 카카오 콘솔에 `http://localhost:8080/login/oauth2/code/kakao` Redirect URI 미등록)은 별도 운영 작업으로 처리 필요.

Generated with [Claude Code](https://claude.com/claude-code)