### PR TITLE
feat(DEVS-12): add LocalTime time field to ToDo

### DIFF
--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
@@ -2,10 +2,12 @@ package com.growit.app.todo.controller.dto.request;
 
 import com.growit.app.todo.controller.dto.response.RoutineDto;
 import com.growit.app.todo.domain.TodoCategory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -16,6 +18,10 @@ public class CreateToDoRequest {
 
   @NotNull(message = "{validation.todo.date.required}")
   private LocalDate date;
+
+  /** 투두 시간 (HH:mm, optional) */
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+  private LocalTime time;
 
   @NotBlank(message = "{validation.todo.content.required}")
   @Size(min = 1, max = 30, message = "{validation.todo.content.size}")

--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
@@ -1,5 +1,6 @@
 package com.growit.app.todo.controller.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
 import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
@@ -7,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,6 +19,10 @@ public class UpdateToDoRequest {
 
   @NotNull(message = "{validation.todo.date.required}")
   private LocalDate date;
+
+  /** 투두 시간 (HH:mm, optional) */
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+  private LocalTime time;
 
   @NotBlank(message = "{validation.todo.content.required}")
   @Size(min = 1, max = 30, message = "{validation.todo.content.size}")

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
@@ -13,6 +13,8 @@ public class TodoDto {
   private String id;
   private String goalId;
   private String date;
+  /** 투두 시간 (HH:mm, optional) */
+  private String time;
   private String content;
 
   private TodoCategory category;

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
@@ -19,6 +19,7 @@ public class ToDoRequestMapper {
         request.getGoalId(),
         request.getContent(),
         request.getDate(),
+        request.getTime(),
         request.getCategory(),
         toDomainRoutine(request.getRoutine()));
   }
@@ -30,6 +31,7 @@ public class ToDoRequestMapper {
         request.getGoalId(),
         request.getContent(),
         request.getDate(),
+        request.getTime(),
         request.getCategory(),
         toDomainRoutine(request.getRoutine()),
         request.getRoutine() != null && request.getRoutineUpdateType() == null

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
@@ -25,6 +25,11 @@ public class ToDoResponseMapper {
         .id(todo.getId())
         .goalId(todo.getGoalId())
         .date(todo.getDate().toString())
+        .time(
+            todo.getTime() != null
+                ? todo.getTime()
+                    .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm"))
+                : null)
         .content(todo.getContent())
         .category(todo.getCategory())
         .completed(todo.isCompleted())

--- a/app/src/main/java/com/growit/app/todo/domain/ToDo.java
+++ b/app/src/main/java/com/growit/app/todo/domain/ToDo.java
@@ -7,6 +7,7 @@ import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.vo.Routine;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,7 @@ public class ToDo {
   @JsonIgnore private String userId;
   private String content;
   private LocalDate date;
+  private LocalTime time;
   private boolean isCompleted;
   private boolean isDeleted;
 
@@ -34,6 +36,7 @@ public class ToDo {
         .goalId(command.goalId())
         .content(command.content())
         .date(command.date())
+        .time(command.time())
         .isCompleted(false)
         .isDeleted(false)
         .category(command.category() != null ? command.category() : TodoCategory.NOW)
@@ -43,6 +46,7 @@ public class ToDo {
 
   public void updateBy(UpdateToDoCommand command) {
     this.date = command.date();
+    this.time = command.time();
     this.goalId = command.goalId();
     this.content = command.content();
     this.category = command.category() != null ? command.category() : this.category;
@@ -52,6 +56,7 @@ public class ToDo {
   public void updateContentOnly(UpdateToDoCommand command) {
     // 루틴 정보는 유지하고 내용만 변경
     this.date = command.date();
+    this.time = command.time();
     this.goalId = command.goalId();
     this.content = command.content();
     this.category = command.category() != null ? command.category() : this.category;

--- a/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
@@ -3,11 +3,13 @@ package com.growit.app.todo.domain.dto;
 import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.Routine;
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 public record CreateToDoCommand(
     String userId,
     String goalId,
     String content,
     LocalDate date,
+    LocalTime time,
     TodoCategory category,
     Routine routine) {}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
@@ -4,6 +4,7 @@ import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 public record UpdateToDoCommand(
     String id,
@@ -11,6 +12,7 @@ public record UpdateToDoCommand(
     String goalId,
     String content,
     LocalDate date,
+    LocalTime time,
     TodoCategory category,
     Routine routine,
     RoutineUpdateType routineUpdateType) {}

--- a/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
+++ b/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
@@ -29,6 +29,7 @@ public class RoutineServiceImpl implements RoutineService {
         command.userId(),
         command.goalId(),
         command.content(),
+        command.time(),
         command.category(),
         command.date(),
         command.routine().getDuration().getStartDate(),
@@ -269,6 +270,7 @@ public class RoutineServiceImpl implements RoutineService {
               command.goalId(),
               command.content(),
               command.date(),
+              command.time(),
               command.category(),
               command.routine());
       return createRoutineToDos(createCommand);
@@ -279,6 +281,7 @@ public class RoutineServiceImpl implements RoutineService {
               command.goalId(),
               command.content(),
               command.date(),
+              command.time(),
               command.category(),
               null);
       ToDo newToDo = ToDo.from(createCommand);
@@ -293,6 +296,7 @@ public class RoutineServiceImpl implements RoutineService {
         command.userId(),
         command.goalId(),
         command.content(),
+        command.time(),
         command.category(),
         command.date(),
         fromDate,
@@ -304,6 +308,7 @@ public class RoutineServiceImpl implements RoutineService {
       String userId,
       String goalId,
       String content,
+      java.time.LocalTime time,
       TodoCategory category,
       LocalDate baseDate,
       LocalDate startDate,
@@ -316,7 +321,7 @@ public class RoutineServiceImpl implements RoutineService {
     String firstToDoId = null;
     for (LocalDate date : dates) {
       CreateToDoCommand routineCommand =
-          new CreateToDoCommand(userId, goalId, content, date, category, sharedRoutine);
+          new CreateToDoCommand(userId, goalId, content, date, time, category, sharedRoutine);
 
       ToDo toDo = ToDo.from(routineCommand);
       toDoRepository.saveToDo(toDo);

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
@@ -22,6 +22,7 @@ public class ToDoDBMapper {
         .goalId(todo.getGoalId())
         .content(todo.getContent())
         .date(todo.getDate())
+        .time(todo.getTime())
         .isCompleted(todo.isCompleted())
         .category(todo.getCategory() != null ? todo.getCategory().name() : "NOW")
         .routineId(routineId)
@@ -37,6 +38,7 @@ public class ToDoDBMapper {
         .userId(entity.getUserId())
         .content(entity.getContent())
         .date(entity.getDate())
+        .time(entity.getTime())
         .isCompleted(entity.isCompleted())
         .isDeleted(entity.getDeletedAt() != null)
         .category(

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.*;
 
 @Entity
@@ -28,6 +29,9 @@ public class ToDoEntity extends BaseEntity {
   @Column(nullable = false)
   private LocalDate date;
 
+  @Column(nullable = true)
+  private LocalTime time;
+
   @Column(nullable = false) // 5자이상 30자이내로 하고 싶음
   private String content;
 
@@ -42,6 +46,7 @@ public class ToDoEntity extends BaseEntity {
 
   public void updateToByDomain(ToDo toDo) {
     this.date = toDo.getDate();
+    this.time = toDo.getTime();
     this.content = toDo.getContent();
     this.isCompleted = toDo.isCompleted();
     this.category = toDo.getCategory() != null ? toDo.getCategory().name() : "NOW";

--- a/app/src/main/resources/db/migration/V34__add_time_to_todos.sql
+++ b/app/src/main/resources/db/migration/V34__add_time_to_todos.sql
@@ -1,0 +1,1 @@
+ALTER TABLE todos ADD COLUMN time TIME NULL;

--- a/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
+++ b/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
@@ -22,7 +22,7 @@ public class ToDoFixture {
 
   public static CreateToDoRequest defaultCreateToDoRequest() {
     return new CreateToDoRequest(
-        "goal-1", LocalDate.now(), "할 일 예시 내용입니다.", TodoCategory.NOW, null);
+        "goal-1", LocalDate.now(), null, "할 일 예시 내용입니다.", TodoCategory.NOW, null);
   }
 
   public static Map<String, List<WeeklyTodosResponse>> weeklyTodosMapWith(

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -111,7 +111,8 @@ class ToDoControllerTest {
             .build();
 
     CreateToDoRequest request =
-        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", TodoCategory.NOW, routineDto);
+        new CreateToDoRequest(
+            "goal-1", LocalDate.now(), null, "할 일 내용", TodoCategory.NOW, routineDto);
 
     Routine domainRoutine =
         Routine.of(
@@ -121,7 +122,13 @@ class ToDoControllerTest {
 
     CreateToDoCommand command =
         new CreateToDoCommand(
-            "user-1", "goal-1", "할 일 내용", LocalDate.now(), TodoCategory.NOW, domainRoutine);
+            "user-1",
+            "goal-1",
+            "할 일 내용",
+            LocalDate.now(),
+            null,
+            TodoCategory.NOW,
+            domainRoutine);
     ToDoResult result = new ToDoResult("todo-1");
     ToDoResponse response = new ToDoResponse("todo-1");
 
@@ -154,6 +161,10 @@ class ToDoControllerTest {
                             fieldWithPath("date")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 날짜 (yyyy-MM-dd)"),
+                            fieldWithPath("time")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description("ToDo 시간 (HH:mm, optional)"),
                             fieldWithPath("content")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 내용 (1-30자)"),
@@ -221,6 +232,7 @@ class ToDoControllerTest {
         new UpdateToDoRequest(
             "goal-1",
             LocalDate.now(),
+            null,
             "수정된 할 일 내용",
             TodoCategory.NOW,
             routineDto,
@@ -232,9 +244,11 @@ class ToDoControllerTest {
             "goal-1",
             "수정된 할 일 내용",
             LocalDate.now(),
+            null,
             TodoCategory.NOW,
             routine,
             RoutineUpdateType.ALL);
+    // time argument inserted at index 5 to match new signature (date, time, category, ...)
 
     ToDoResult result = new ToDoResult("todo-123");
 
@@ -270,6 +284,10 @@ class ToDoControllerTest {
                             fieldWithPath("date")
                                 .type(JsonFieldType.STRING)
                                 .description("수정할 ToDo 날짜 (yyyy-MM-dd)"),
+                            fieldWithPath("time")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description("수정할 ToDo 시간 (HH:mm, optional)"),
                             fieldWithPath("content")
                                 .type(JsonFieldType.STRING)
                                 .description("수정할 ToDo 내용 (1-30자)"),
@@ -329,6 +347,7 @@ class ToDoControllerTest {
         new UpdateToDoRequest(
             "goal-123",
             LocalDate.of(2024, 1, 1),
+            null,
             "Updated routine task",
             TodoCategory.NOW,
             routineDto,
@@ -341,6 +360,7 @@ class ToDoControllerTest {
             "goal-123",
             "Updated routine task",
             LocalDate.of(2024, 1, 1),
+            null,
             TodoCategory.NOW,
             null,
             RoutineUpdateType.FROM_DATE);
@@ -541,6 +561,10 @@ class ToDoControllerTest {
                             fieldWithPath("data[].todo.date")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 날짜"),
+                            fieldWithPath("data[].todo.time")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description("ToDo 시간 (HH:mm, optional)"),
                             fieldWithPath("data[].todo.content")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 내용"),
@@ -640,6 +664,10 @@ class ToDoControllerTest {
                             fieldWithPath("data.date")
                                 .type(JsonFieldType.STRING)
                                 .description("ToDo 날짜"),
+                            fieldWithPath("data.time")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description("ToDo 시간 (HH:mm, optional)"),
                             fieldWithPath("data.isCompleted")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("완료 여부"),

--- a/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
+++ b/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
@@ -54,6 +54,7 @@ class RoutineServiceTest {
             "goal123",
             "Daily routine task",
             LocalDate.of(2024, 1, 1),
+            null,
             TodoCategory.NOW,
             routine);
 
@@ -64,6 +65,7 @@ class RoutineServiceTest {
             "goal123",
             "Updated routine task",
             LocalDate.of(2024, 1, 3),
+            null,
             TodoCategory.NOW,
             routine,
             RoutineUpdateType.FROM_DATE);
@@ -129,6 +131,7 @@ class RoutineServiceTest {
             "goal123",
             "Updated all routine tasks",
             LocalDate.of(2024, 1, 3),
+            null,
             TodoCategory.NOW,
             routine,
             RoutineUpdateType.ALL);
@@ -160,6 +163,7 @@ class RoutineServiceTest {
             "goal123",
             "Updated single task",
             LocalDate.of(2024, 1, 3),
+            null,
             TodoCategory.NOW,
             null, // 루틴 제거
             RoutineUpdateType.SINGLE);
@@ -187,6 +191,7 @@ class RoutineServiceTest {
             "goal123",
             "Weekly routine task",
             LocalDate.of(2024, 1, 1),
+            null,
             TodoCategory.NOW,
             weeklyRoutine);
 
@@ -229,6 +234,7 @@ class RoutineServiceTest {
             "goal123",
             "Weekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
+            null,
             TodoCategory.NOW,
             weeklyRoutineWithDays);
 
@@ -258,6 +264,7 @@ class RoutineServiceTest {
             "goal123",
             "Biweekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
+            null,
             TodoCategory.NOW,
             biweeklyRoutine);
 
@@ -286,6 +293,7 @@ class RoutineServiceTest {
             "goal123",
             "Weekly routine without specific days",
             LocalDate.of(2024, 1, 1), // 월요일
+            null,
             TodoCategory.NOW,
             weeklyRoutineWithoutDays);
 
@@ -315,6 +323,7 @@ class RoutineServiceTest {
             "goal123",
             "Daily routine with repeatDays",
             LocalDate.of(2024, 1, 1),
+            null,
             TodoCategory.NOW,
             dailyRoutineWithDays);
 

--- a/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
@@ -50,7 +50,7 @@ class CreateToDoUseCaseTest {
 
     simpleCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Simple task", LocalDate.now(), TodoCategory.NOW, null);
+            "user123", "goal123", "Simple task", LocalDate.now(), null, TodoCategory.NOW, null);
 
     RoutineDuration duration =
         RoutineDuration.of(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7));
@@ -63,6 +63,7 @@ class CreateToDoUseCaseTest {
             "goal123",
             "Routine task",
             LocalDate.of(2024, 1, 1),
+            null,
             TodoCategory.NOW,
             routine);
   }

--- a/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
@@ -51,7 +51,15 @@ class UpdateToDoUseCaseTest {
     String newContent = "수정된 내용";
     UpdateToDoCommand command =
         new UpdateToDoCommand(
-            toDo.getId(), toDo.getUserId(), toDo.getGoalId(), newContent, today, null, null, null);
+            toDo.getId(),
+            toDo.getUserId(),
+            toDo.getGoalId(),
+            newContent,
+            today,
+            null,
+            null,
+            null,
+            null);
 
     // When
     ToDoResult result = updateToDoUseCase.execute(command);


### PR DESCRIPTION
## Summary
- ToDo 도메인에 nullable `LocalTime time` 추가 (FE의 \"오전 9:30\" 스타일 시간 표시 지원)
- V34 마이그레이션: `todo` 테이블에 nullable `TIME` 컬럼 추가
- API: Create/Update Request에 `time: \"HH:mm\"` (선택) 노출, Response의 TodoDto가 HH:mm로 echo

## Why
DEVS-12 홈 매트릭스 뷰의 List/Detail 화면에서 시간 표시(`AM 10:45`)가 필요. 기존 `date: LocalDate`로는 시간 표현 불가 → datetime 분리 결정.

## Changes
- **Schema**: `V34__add_time_to_todos.sql`
- **Domain**: `ToDo.time: LocalTime?`, `ToDo.from/updateBy/updateContentOnly` 시그니처 확장
- **Persistence**: `ToDoEntity.time` + `ToDoEntity.updateToByDomain`, `ToDoDBMapper` 양방향
- **API**: `CreateToDoRequest`/`UpdateToDoRequest`에 `time` (Jackson `@JsonFormat`)
- **Command**: `CreateToDoCommand`/`UpdateToDoCommand` 슬롯 추가, `ToDoRequestMapper` 통과
- **Routine**: `RoutineServiceImpl`이 routine-generated ToDo에도 time 전파
- **Tests / restdocs** 업데이트

## Test plan
- [ ] `POST /todos` with `time: \"09:30\"` → 200, response에 `time: \"09:30\"`
- [ ] `POST /todos` without `time` → 200, response의 `time: null`
- [ ] `PUT /todos/{id}`로 시간 갱신 → 응답에 새 시간
- [ ] V34 마이그레이션이 develop dev DB에 정상 적용
- [ ] 기존 todo (time=null)도 정상 조회

## Notion
DEVS-12: https://www.notion.so/350bf989e8858078b3c1f3fcdbcd88c7

## Related PRs
- DDD-12-GROWIT-FE #284 (feat/DEVS-12-home-redesign) — 본 PR의 time 필드를 wire

Generated with [Claude Code](https://claude.com/claude-code)