### PR TITLE
feat(DEVS-12): include per-category counts in /todos/count response

### DIFF
--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoCountByDateResponse.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoCountByDateResponse.java
@@ -28,5 +28,6 @@ public class TodoCountByDateResponse {
   public static class CategoryTodoCount {
     private TodoCategory category;
     private int todoCount;
+    private int completedCount;
   }
 }

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoCountByDateResponse.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoCountByDateResponse.java
@@ -1,5 +1,6 @@
 package com.growit.app.todo.controller.dto.response;
 
+import com.growit.app.todo.domain.TodoCategory;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,12 +12,21 @@ import lombok.Getter;
 public class TodoCountByDateResponse {
   private String date;
   private List<GoalTodoCount> goals;
+  private List<CategoryTodoCount> categories;
 
   @Getter
   @Builder
   @AllArgsConstructor
   public static class GoalTodoCount {
     private String id;
+    private int todoCount;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class CategoryTodoCount {
+    private TodoCategory category;
     private int todoCount;
   }
 }

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
@@ -70,6 +70,7 @@ public class ToDoResponseMapper {
                     TodoCountByDateResponse.CategoryTodoCount.builder()
                         .category(cc.getCategory())
                         .todoCount(cc.getTodoCount())
+                        .completedCount(cc.getCompletedCount())
                         .build())
             .toList();
 

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
@@ -63,9 +63,20 @@ public class ToDoResponseMapper {
                         .build())
             .toList();
 
+    List<TodoCountByDateResponse.CategoryTodoCount> categoryCounts =
+        dto.getCategoryCounts().stream()
+            .map(
+                cc ->
+                    TodoCountByDateResponse.CategoryTodoCount.builder()
+                        .category(cc.getCategory())
+                        .todoCount(cc.getTodoCount())
+                        .build())
+            .toList();
+
     return TodoCountByDateResponse.builder()
         .date(dto.getDate().toString())
         .goals(goalCounts)
+        .categories(categoryCounts)
         .build();
   }
 

--- a/app/src/main/java/com/growit/app/todo/usecase/GetTodoCountByGoalInDateRangeUseCase.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/GetTodoCountByGoalInDateRangeUseCase.java
@@ -51,18 +51,25 @@ public class GetTodoCountByGoalInDateRangeUseCase {
                           entry.getKey(), entry.getValue().intValue()))
               .toList();
 
-      // Count todos by category for this date (FE 캘린더 인디케이터용)
-      Map<TodoCategory, Long> todoCountByCategory =
+      // Count todos by category for this date (FE 캘린더 인디케이터용).
+      // Each category exposes both total and completed count so the FE can
+      // dim the dot when an incomplete todo remains (DS 196:1610: opacity
+      // 40% if any incomplete, 100% if all done).
+      Map<TodoCategory, List<ToDo>> todosByCategory =
           todosForDate.stream()
               .filter(todo -> todo.getCategory() != null)
-              .collect(Collectors.groupingBy(ToDo::getCategory, Collectors.counting()));
+              .collect(Collectors.groupingBy(ToDo::getCategory));
 
       List<TodoCountByDateDto.CategoryTodoCount> categoryCounts =
-          todoCountByCategory.entrySet().stream()
+          todosByCategory.entrySet().stream()
               .map(
-                  entry ->
-                      new TodoCountByDateDto.CategoryTodoCount(
-                          entry.getKey(), entry.getValue().intValue()))
+                  entry -> {
+                    int total = entry.getValue().size();
+                    int completed =
+                        (int) entry.getValue().stream().filter(ToDo::isCompleted).count();
+                    return new TodoCountByDateDto.CategoryTodoCount(
+                        entry.getKey(), total, completed);
+                  })
               .toList();
 
       result.add(new TodoCountByDateDto(currentDate, goalCounts, categoryCounts));

--- a/app/src/main/java/com/growit/app/todo/usecase/GetTodoCountByGoalInDateRangeUseCase.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/GetTodoCountByGoalInDateRangeUseCase.java
@@ -2,6 +2,7 @@ package com.growit.app.todo.usecase;
 
 import com.growit.app.todo.domain.ToDo;
 import com.growit.app.todo.domain.ToDoRepository;
+import com.growit.app.todo.domain.TodoCategory;
 import com.growit.app.todo.domain.dto.GetDateRangeQueryFilter;
 import com.growit.app.todo.usecase.dto.TodoCountByDateDto;
 import java.time.LocalDate;
@@ -50,7 +51,21 @@ public class GetTodoCountByGoalInDateRangeUseCase {
                           entry.getKey(), entry.getValue().intValue()))
               .toList();
 
-      result.add(new TodoCountByDateDto(currentDate, goalCounts));
+      // Count todos by category for this date (FE 캘린더 인디케이터용)
+      Map<TodoCategory, Long> todoCountByCategory =
+          todosForDate.stream()
+              .filter(todo -> todo.getCategory() != null)
+              .collect(Collectors.groupingBy(ToDo::getCategory, Collectors.counting()));
+
+      List<TodoCountByDateDto.CategoryTodoCount> categoryCounts =
+          todoCountByCategory.entrySet().stream()
+              .map(
+                  entry ->
+                      new TodoCountByDateDto.CategoryTodoCount(
+                          entry.getKey(), entry.getValue().intValue()))
+              .toList();
+
+      result.add(new TodoCountByDateDto(currentDate, goalCounts, categoryCounts));
       currentDate = currentDate.plusDays(1);
     }
 

--- a/app/src/main/java/com/growit/app/todo/usecase/dto/TodoCountByDateDto.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/dto/TodoCountByDateDto.java
@@ -25,5 +25,6 @@ public class TodoCountByDateDto {
   public static class CategoryTodoCount {
     private final TodoCategory category;
     private final int todoCount;
+    private final int completedCount;
   }
 }

--- a/app/src/main/java/com/growit/app/todo/usecase/dto/TodoCountByDateDto.java
+++ b/app/src/main/java/com/growit/app/todo/usecase/dto/TodoCountByDateDto.java
@@ -1,5 +1,6 @@
 package com.growit.app.todo.usecase.dto;
 
+import com.growit.app.todo.domain.TodoCategory;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -10,11 +11,19 @@ import lombok.Getter;
 public class TodoCountByDateDto {
   private final LocalDate date;
   private final List<GoalTodoCount> goalCounts;
+  private final List<CategoryTodoCount> categoryCounts;
 
   @Getter
   @AllArgsConstructor
   public static class GoalTodoCount {
     private final String goalId;
+    private final int todoCount;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class CategoryTodoCount {
+    private final TodoCategory category;
     private final int todoCount;
   }
 }

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -712,12 +712,18 @@ class ToDoControllerTest {
                 LocalDate.of(2024, 1, 1),
                 List.of(
                     new TodoCountByDateDto.GoalTodoCount("goal-1", 3),
-                    new TodoCountByDateDto.GoalTodoCount("goal-2", 2))),
+                    new TodoCountByDateDto.GoalTodoCount("goal-2", 2)),
+                List.of(
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.NOW, 3),
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.STEADY, 2))),
             new TodoCountByDateDto(
                 LocalDate.of(2024, 1, 2),
                 List.of(
                     new TodoCountByDateDto.GoalTodoCount("goal-1", 1),
-                    new TodoCountByDateDto.GoalTodoCount("goal-2", 4))));
+                    new TodoCountByDateDto.GoalTodoCount("goal-2", 4)),
+                List.of(
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.SKIP, 1),
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.DELETE, 4))));
     List<TodoCountByDateResponse> responseList =
         List.of(
             TodoCountByDateResponse.builder()
@@ -726,6 +732,10 @@ class ToDoControllerTest {
                     List.of(
                         new TodoCountByDateResponse.GoalTodoCount("goal-1", 3),
                         new TodoCountByDateResponse.GoalTodoCount("goal-2", 2)))
+                .categories(
+                    List.of(
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.NOW, 3),
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.STEADY, 2)))
                 .build(),
             TodoCountByDateResponse.builder()
                 .date("2024-01-02")
@@ -733,6 +743,10 @@ class ToDoControllerTest {
                     List.of(
                         new TodoCountByDateResponse.GoalTodoCount("goal-1", 1),
                         new TodoCountByDateResponse.GoalTodoCount("goal-2", 4)))
+                .categories(
+                    List.of(
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.SKIP, 1),
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.DELETE, 4)))
                 .build());
 
     given(toDoRequestMapper.toGetDateRangeQueryFilter(any(String.class), eq(from), eq(to)))
@@ -777,7 +791,16 @@ class ToDoControllerTest {
                                 .description("목표 ID"),
                             fieldWithPath("data[].goals[].todoCount")
                                 .type(JsonFieldType.NUMBER)
-                                .description("해당 목표의 ToDo 개수"))
+                                .description("해당 목표의 ToDo 개수"),
+                            fieldWithPath("data[].categories")
+                                .type(JsonFieldType.ARRAY)
+                                .description("카테고리별 ToDo 개수 배열 (캘린더 인디케이터용)"),
+                            fieldWithPath("data[].categories[].category")
+                                .type(JsonFieldType.STRING)
+                                .description("카테고리 (NOW/STEADY/SKIP/DELETE)"),
+                            fieldWithPath("data[].categories[].todoCount")
+                                .type(JsonFieldType.NUMBER)
+                                .description("해당 카테고리의 ToDo 개수"))
                         .build())));
   }
 }

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -714,16 +714,16 @@ class ToDoControllerTest {
                     new TodoCountByDateDto.GoalTodoCount("goal-1", 3),
                     new TodoCountByDateDto.GoalTodoCount("goal-2", 2)),
                 List.of(
-                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.NOW, 3),
-                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.STEADY, 2))),
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.NOW, 3, 1),
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.STEADY, 2, 2))),
             new TodoCountByDateDto(
                 LocalDate.of(2024, 1, 2),
                 List.of(
                     new TodoCountByDateDto.GoalTodoCount("goal-1", 1),
                     new TodoCountByDateDto.GoalTodoCount("goal-2", 4)),
                 List.of(
-                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.SKIP, 1),
-                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.DELETE, 4))));
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.SKIP, 1, 0),
+                    new TodoCountByDateDto.CategoryTodoCount(TodoCategory.DELETE, 4, 4))));
     List<TodoCountByDateResponse> responseList =
         List.of(
             TodoCountByDateResponse.builder()
@@ -734,8 +734,8 @@ class ToDoControllerTest {
                         new TodoCountByDateResponse.GoalTodoCount("goal-2", 2)))
                 .categories(
                     List.of(
-                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.NOW, 3),
-                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.STEADY, 2)))
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.NOW, 3, 1),
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.STEADY, 2, 2)))
                 .build(),
             TodoCountByDateResponse.builder()
                 .date("2024-01-02")
@@ -745,8 +745,8 @@ class ToDoControllerTest {
                         new TodoCountByDateResponse.GoalTodoCount("goal-2", 4)))
                 .categories(
                     List.of(
-                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.SKIP, 1),
-                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.DELETE, 4)))
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.SKIP, 1, 0),
+                        new TodoCountByDateResponse.CategoryTodoCount(TodoCategory.DELETE, 4, 4)))
                 .build());
 
     given(toDoRequestMapper.toGetDateRangeQueryFilter(any(String.class), eq(from), eq(to)))
@@ -800,7 +800,10 @@ class ToDoControllerTest {
                                 .description("카테고리 (NOW/STEADY/SKIP/DELETE)"),
                             fieldWithPath("data[].categories[].todoCount")
                                 .type(JsonFieldType.NUMBER)
-                                .description("해당 카테고리의 ToDo 개수"))
+                                .description("해당 카테고리의 ToDo 개수"),
+                            fieldWithPath("data[].categories[].completedCount")
+                                .type(JsonFieldType.NUMBER)
+                                .description("해당 카테고리의 완료된 ToDo 개수"))
                         .build())));
   }
 }


### PR DESCRIPTION
## Summary
- `/todos/count` 응답을 카테고리별 카운트로 확장: 카테고리당 `todoCount`(총 todo 수) + `completedCount`(완료된 todo 수) 제공
- FE 캘린더 셀의 인디케이터(NOW/STEADY)에서 \"전부 완료\"는 100% opacity, \"일부 미완료\"는 40% opacity 표현에 사용

## Why
DEVS-12 캘린더 인디케이터 사양 (Figma DS calendar-day 196:1610)에 따라 FE는 카테고리별 \"todo가 있는지\" + \"전부 완료됐는지\"를 모두 알아야 함. 기존 응답은 todoCount만 있어 완료 상태를 알 수 없음.

## Changes
- `TodoCountByDateDto.CategoryTodoCount`: `completedCount` 필드 추가
- `TodoCountByDateResponse.CategoryTodoCount`: 동일 미러
- `GetTodoCountByGoalInDateRangeUseCase`: 카테고리별로 `ToDo.isCompleted()` 카운트
- 매퍼: `completedCount` 통과
- Controller test 업데이트

## Test plan
- [ ] `GET /todos/count?from=&to=` → 응답의 각 날짜 × 카테고리별로 `{todoCount, completedCount}` 포함
- [ ] 모든 todo가 완료된 카테고리 → `completedCount == todoCount`
- [ ] 일부 미완료 카테고리 → `completedCount < todoCount`
- [ ] todo 0개 카테고리 → `{todoCount: 0, completedCount: 0}` 또는 entry 없음

## Notion
DEVS-12: https://www.notion.so/350bf989e8858078b3c1f3fcdbcd88c7

## Related PRs
- DDD-12-GROWIT-BE #440 (feat/DEVS-12-todo-time-field) — 동일 티켓 BE 작업
- DDD-12-GROWIT-FE #284 — 본 PR의 카테고리별 카운트를 캘린더 인디케이터로 사용

Generated with [Claude Code](https://claude.com/claude-code)