### PR TITLE
fix: AI 서버 호출 토글(ai.enabled) 추가로 점검 중 요청 차단

### DIFF
--- a/app/src/main/java/com/growit/app/advice/batch/config/MorningAdviceJobConfig.java
+++ b/app/src/main/java/com/growit/app/advice/batch/config/MorningAdviceJobConfig.java
@@ -25,6 +25,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
@@ -43,6 +44,9 @@ public class MorningAdviceJobConfig {
   private final ChatAdviceDataCollector chatAdviceDataCollector;
   private final ChatAdviceClient chatAdviceClient;
   private final Clock clock;
+
+  @Value("${ai.enabled:false}")
+  private boolean aiEnabled;
 
   @Bean
   public Job morningAdviceJob() {
@@ -88,6 +92,6 @@ public class MorningAdviceJobConfig {
 
   @Bean
   public MorningAdviceWriter morningAdviceWriter() {
-    return new MorningAdviceWriter(chatAdviceClient, chatAdviceRepository);
+    return new MorningAdviceWriter(chatAdviceClient, chatAdviceRepository, aiEnabled);
   }
 }

--- a/app/src/main/java/com/growit/app/advice/batch/writer/MorningAdviceWriter.java
+++ b/app/src/main/java/com/growit/app/advice/batch/writer/MorningAdviceWriter.java
@@ -21,9 +21,15 @@ public class MorningAdviceWriter implements ItemWriter<ChatAdviceRequest> {
 
   private final ChatAdviceClient chatAdviceClient;
   private final ChatAdviceRepository chatAdviceRepository;
+  private final boolean aiEnabled;
 
   @Override
   public void write(Chunk<? extends ChatAdviceRequest> chunk) throws Exception {
+    if (!aiEnabled) {
+      log.warn("AI 기능이 비활성화되어 아침 조언 생성을 건너뜁니다. count={}", chunk.size());
+      return;
+    }
+
     for (ChatAdviceRequest request : chunk) {
       try {
         log.debug("Requesting AI advice for user: {}", request.getUserId());

--- a/app/src/main/java/com/growit/app/advice/usecase/GenerateMentorAdviceUseCase.java
+++ b/app/src/main/java/com/growit/app/advice/usecase/GenerateMentorAdviceUseCase.java
@@ -11,10 +11,13 @@ import com.growit.app.goal.usecase.GetUserGoalsUseCase;
 import com.growit.app.user.domain.user.User;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** 멘토 조언 생성 UseCase - 진행 중인 목표 확인 - 조언 데이터 수집 - AI 조언 생성 */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -24,14 +27,23 @@ public class GenerateMentorAdviceUseCase {
   private final MentorAdviceDataCollector dataCollector;
   private final MentorAdviceService mentorAdviceService;
 
+  /** AI 서버 호출 토글. false면 AI 요청을 보내지 않고 조언 생성을 건너뜁니다. */
+  @Value("${ai.enabled:false}")
+  private boolean aiEnabled;
+
   /**
    * 멘토 조언을 생성합니다.
    *
    * @param user 사용자
-   * @return 생성된 멘토 조언
+   * @return 생성된 멘토 조언, AI 멘토 기능이 비활성화된 경우 null
    * @throws NotFoundException 진행 중인 목표가 없는 경우
    */
   public MentorAdvice execute(User user) {
+    if (!aiEnabled) {
+      log.warn("AI 멘토 기능이 비활성화되어 조언 생성을 건너뜁니다. userId={}", user.getId());
+      return null;
+    }
+
     Goal currentGoal = getCurrentProgressGoal(user);
     MentorAdviceData data = dataCollector.collectData(user, currentGoal);
 
@@ -45,6 +57,11 @@ public class GenerateMentorAdviceUseCase {
    * @return 생성된 멘토 조언 (조건이 맞지 않으면 Optional.empty())
    */
   public Optional<MentorAdvice> tryExecute(User user) {
+    if (!aiEnabled) {
+      log.warn("AI 멘토 기능이 비활성화되어 조언 생성을 건너뜁니다. userId={}", user.getId());
+      return Optional.empty();
+    }
+
     Optional<Goal> currentGoal = getCurrentProgressGoalOptional(user);
     if (currentGoal.isEmpty()) {
       return Optional.empty(); // 진행중인 목표 없음

--- a/app/src/main/java/com/growit/app/advice/usecase/GetMentorAdviceUseCase.java
+++ b/app/src/main/java/com/growit/app/advice/usecase/GetMentorAdviceUseCase.java
@@ -51,6 +51,10 @@ public class GetMentorAdviceUseCase {
 
   private MentorAdvice createNewMentorAdvice(User user) {
     MentorAdvice newAdvice = generateMentorAdviceUseCase.execute(user);
+    if (newAdvice == null) {
+      // AI 기능 비활성화 등으로 조언을 생성하지 못함 - 저장하지 않고 종료
+      return null;
+    }
     mentorAdviceRepository.save(newAdvice);
     return newAdvice;
   }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -97,6 +97,7 @@ app:
     api-keys:
       - ${GOAL_API_KEY_PRIMARY:}
 ai:
+  enabled: false  # AI 서버 호출 전체 토글 (서버 점검 중 false, 복구 시 true)
   api:
     api-key: ${OPEN_API_KEY}
   mentor:


### PR DESCRIPTION
## 문제

AI 멘토 서버(`growit-ai:3001`)가 점검 등으로 다운된 상황에서 다음 경로가 다운된 서버로 요청을 보내 장애가 발생함:

- `GET /advice/mentor` (daily-advice): WebClient가 503을 받고 `WebClientResponseException`을 던짐 → `GlobalExceptionHandler`가 500으로 응답 + Discord 알림 발송
- 매일 7AM `morningAdviceJob` 배치: `ChatAdviceClient.getMorningAdvice` 호출 실패 → 배치 실패

## 해결

`ai.enabled` 토글을 추가해 **AI 서버로 가는 호출 자체를 건너뛰도록** 함. 점검 중에는 `false`, 복구 후 `true`로 한 줄만 바꾸면 됨 (배포 환경변수/파이프라인 수정 불필요).

## 변경

| 파일 | 변경 |
|---|---|
| `application.yml` | `ai.enabled: false` 토글 추가 |
| `GenerateMentorAdviceUseCase` | `false`면 daily-advice 호출 스킵, `null` 반환 |
| `GetMentorAdviceUseCase` | 조언이 `null`이면 저장 스킵 → 컨트롤러가 **200 OK** 응답 (`data: null`) |
| `MorningAdviceWriter` | `false`면 아침 조언 호출 스킵 (배치는 정상 완료) |
| `MorningAdviceJobConfig` | writer에 토글 주입 |

## 동작 변화

| 상황 | 이전 | 이후 |
|---|---|---|
| AI 서버 다운 + `/advice/mentor` 첫 요청 | 500 + Discord 🚨 | **200 OK** with `data: null` |
| AI 서버 다운 + `/advice/mentor` 캐시 있음 | 캐시 반환 | 캐시 반환 (변화 없음) |
| AI 서버 다운 + 7AM 배치 | 배치 실패 | 배치 정상 완료 (writer 스킵) |
| `/advice/mentor` + 진행중 목표 없음 | 404 | 404 (변화 없음) |

## 복구 시

`app/src/main/resources/application.yml`의 `ai.enabled: false` → `true`로 변경 후 배포.

## 범위 밖

같은 `ai.mentor.url`을 사용하는 다른 경로(`ChatAdviceClient.getRealtimeAdvice`, `GoalRetrospectAnalysisClient`)는 현재 호출 경로가 없어 이번 PR에서 제외함.

## 테스트

- `./gradlew test` 전체 통과
- `spotlessApply` 적용 완료
- 기존 `GetMentorAdviceUseCaseTest`는 `GenerateMentorAdviceUseCase`를 모킹하므로 토글 영향 없이 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)