### PR TITLE
fix: add ToDoCategory field so 4-chip category selection persists

### DIFF
--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
@@ -2,6 +2,7 @@ package com.growit.app.todo.controller.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -22,6 +23,8 @@ public class CreateToDoRequest {
   private String content;
 
   private boolean isImportant;
+
+  private ToDoCategory category;
 
   private RoutineDto routine;
 

--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
@@ -3,6 +3,7 @@ package com.growit.app.todo.controller.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -24,6 +25,8 @@ public class UpdateToDoRequest {
 
   @JsonProperty("isImportant")
   private Boolean important; // Use Boolean wrapper to allow null values
+
+  private ToDoCategory category; // nullable
 
   private RoutineDto routine; // nullable
   private RoutineUpdateType routineUpdateType; // nullable

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
@@ -1,6 +1,7 @@
 package com.growit.app.todo.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,8 @@ public class TodoDto {
 
   @JsonProperty("isCompleted")
   private boolean completed;
+
+  private ToDoCategory category;
 
   private RoutineDto routine;
 }

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/WeeklyTodosResponse.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/WeeklyTodosResponse.java
@@ -3,6 +3,7 @@ package com.growit.app.todo.controller.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.domain.ToDo;
 import com.growit.app.todo.domain.vo.Routine;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,6 +21,8 @@ public class WeeklyTodosResponse {
   @JsonProperty("isImportant")
   private boolean important;
 
+  private ToDoCategory category;
+
   private Routine routine;
 
   public static WeeklyTodosResponse from(ToDo todo) {
@@ -30,6 +33,7 @@ public class WeeklyTodosResponse {
         .content(todo.getContent())
         .completed(todo.isCompleted())
         .important(todo.isImportant())
+        .category(todo.getCategory())
         .routine(todo.getRoutine())
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
@@ -19,6 +19,7 @@ public class ToDoRequestMapper {
         request.getContent(),
         request.getDate(),
         request.isImportant(),
+        request.getCategory(),
         toDomainRoutine(request.getRoutine()));
   }
 
@@ -30,6 +31,7 @@ public class ToDoRequestMapper {
         request.getContent(),
         request.getDate(),
         request.getImportant() != null ? request.getImportant() : false,
+        request.getCategory(),
         toDomainRoutine(request.getRoutine()),
         request.getRoutine() != null && request.getRoutineUpdateType() == null
             ? RoutineUpdateType.ALL

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
@@ -28,6 +28,7 @@ public class ToDoResponseMapper {
         .content(todo.getContent())
         .important(todo.isImportant())
         .completed(todo.isCompleted())
+        .category(todo.getCategory())
         .routine(toRoutineDto(todo.getRoutine()))
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/domain/ToDo.java
+++ b/app/src/main/java/com/growit/app/todo/domain/ToDo.java
@@ -6,6 +6,7 @@ import com.growit.app.common.util.IDGenerator;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.vo.Routine;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,8 @@ public class ToDo {
   @JsonProperty("isImportant")
   private boolean isImportant;
 
+  private ToDoCategory category;
+
   private Routine routine;
 
   public static ToDo from(CreateToDoCommand command) {
@@ -38,6 +41,7 @@ public class ToDo {
         .isCompleted(false)
         .isDeleted(false)
         .isImportant(command.isImportant())
+        .category(command.category() != null ? command.category() : ToDoCategory.URGENT)
         .routine(command.routine())
         .build();
   }
@@ -47,6 +51,9 @@ public class ToDo {
     this.goalId = command.goalId();
     this.content = command.content();
     this.isImportant = command.isImportant();
+    if (command.category() != null) {
+      this.category = command.category();
+    }
     this.routine = command.routine();
   }
 
@@ -56,6 +63,9 @@ public class ToDo {
     this.goalId = command.goalId();
     this.content = command.content();
     this.isImportant = command.isImportant();
+    if (command.category() != null) {
+      this.category = command.category();
+    }
     // routine은 변경하지 않음
   }
 

--- a/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
@@ -1,6 +1,7 @@
 package com.growit.app.todo.domain.dto;
 
 import com.growit.app.todo.domain.vo.Routine;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 
 public record CreateToDoCommand(
@@ -9,4 +10,5 @@ public record CreateToDoCommand(
     String content,
     LocalDate date,
     boolean isImportant,
+    ToDoCategory category,
     Routine routine) {}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
@@ -2,6 +2,7 @@ package com.growit.app.todo.domain.dto;
 
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 
 public record UpdateToDoCommand(
@@ -11,5 +12,6 @@ public record UpdateToDoCommand(
     String content,
     LocalDate date,
     boolean isImportant,
+    ToDoCategory category,
     Routine routine,
     RoutineUpdateType routineUpdateType) {}

--- a/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
+++ b/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
@@ -8,6 +8,7 @@ import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.vo.RepeatType;
 import com.growit.app.todo.domain.vo.Routine;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,7 @@ public class RoutineServiceImpl implements RoutineService {
         command.goalId(),
         command.content(),
         command.isImportant(),
+        command.category(),
         command.date(),
         command.routine().getDuration().getStartDate(),
         command.routine().getDuration().getEndDate());
@@ -269,6 +271,7 @@ public class RoutineServiceImpl implements RoutineService {
               command.content(),
               command.date(),
               command.isImportant(),
+              command.category(),
               command.routine());
       return createRoutineToDos(createCommand);
     } else {
@@ -279,6 +282,7 @@ public class RoutineServiceImpl implements RoutineService {
               command.content(),
               command.date(),
               command.isImportant(),
+              command.category(),
               null);
       ToDo newToDo = ToDo.from(createCommand);
       toDoRepository.saveToDo(newToDo);
@@ -293,6 +297,7 @@ public class RoutineServiceImpl implements RoutineService {
         command.goalId(),
         command.content(),
         command.isImportant(),
+        command.category(),
         command.date(),
         fromDate,
         command.routine().getDuration().getEndDate());
@@ -304,6 +309,7 @@ public class RoutineServiceImpl implements RoutineService {
       String goalId,
       String content,
       boolean isImportant,
+      ToDoCategory category,
       LocalDate baseDate,
       LocalDate startDate,
       LocalDate endDate) {
@@ -315,7 +321,8 @@ public class RoutineServiceImpl implements RoutineService {
     String firstToDoId = null;
     for (LocalDate date : dates) {
       CreateToDoCommand routineCommand =
-          new CreateToDoCommand(userId, goalId, content, date, isImportant, sharedRoutine);
+          new CreateToDoCommand(
+              userId, goalId, content, date, isImportant, category, sharedRoutine);
 
       ToDo toDo = ToDo.from(routineCommand);
       toDoRepository.saveToDo(toDo);

--- a/app/src/main/java/com/growit/app/todo/domain/vo/ToDoCategory.java
+++ b/app/src/main/java/com/growit/app/todo/domain/vo/ToDoCategory.java
@@ -1,0 +1,8 @@
+package com.growit.app.todo.domain.vo;
+
+public enum ToDoCategory {
+  URGENT,
+  CONSISTENT,
+  DEFERABLE,
+  DELETABLE
+}

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
@@ -3,6 +3,7 @@ package com.growit.app.todo.infrastructure.persistence.todo;
 import com.growit.app.todo.domain.ToDo;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineDuration;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import com.growit.app.todo.infrastructure.persistence.todo.source.entity.RoutineEntity;
 import com.growit.app.todo.infrastructure.persistence.todo.source.entity.ToDoEntity;
 import java.time.DayOfWeek;
@@ -23,6 +24,7 @@ public class ToDoDBMapper {
         .date(todo.getDate())
         .isCompleted(todo.isCompleted())
         .isImportant(todo.isImportant())
+        .category(todo.getCategory() != null ? todo.getCategory() : ToDoCategory.URGENT)
         .routineId(routineId)
         .build();
   }
@@ -39,6 +41,7 @@ public class ToDoDBMapper {
         .isCompleted(entity.isCompleted())
         .isDeleted(entity.getDeletedAt() != null)
         .isImportant(entity.isImportant())
+        .category(entity.getCategory() != null ? entity.getCategory() : ToDoCategory.URGENT)
         .routine(routine)
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
@@ -2,8 +2,11 @@ package com.growit.app.todo.infrastructure.persistence.todo.source.entity;
 
 import com.growit.app.common.entity.BaseEntity;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,6 +40,10 @@ public class ToDoEntity extends BaseEntity {
   @Column(nullable = false, columnDefinition = "boolean default false")
   private boolean isImportant;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 32)
+  private ToDoCategory category;
+
   @Column(nullable = true)
   private String routineId;
 
@@ -45,6 +52,7 @@ public class ToDoEntity extends BaseEntity {
     this.content = toDo.getContent();
     this.isCompleted = toDo.isCompleted();
     this.isImportant = toDo.isImportant();
+    this.category = toDo.getCategory() != null ? toDo.getCategory() : ToDoCategory.URGENT;
     this.goalId = toDo.getGoalId();
     if (toDo.getRoutine() != null) {
       this.routineId = toDo.getRoutine().getId();

--- a/app/src/main/resources/db/migration/V33__add_category_to_todos.sql
+++ b/app/src/main/resources/db/migration/V33__add_category_to_todos.sql
@@ -1,0 +1,9 @@
+ALTER TABLE todos
+    ADD category VARCHAR(32);
+
+UPDATE todos
+SET category = 'URGENT'
+WHERE category IS NULL;
+
+ALTER TABLE todos
+    ALTER COLUMN category SET NOT NULL;

--- a/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
+++ b/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
@@ -3,6 +3,7 @@ package com.growit.app.fake.todo;
 import com.growit.app.todo.controller.dto.request.CreateToDoRequest;
 import com.growit.app.todo.controller.dto.response.WeeklyTodosResponse;
 import com.growit.app.todo.domain.ToDo;
+import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -20,7 +21,7 @@ public class ToDoFixture {
   }
 
   public static CreateToDoRequest defaultCreateToDoRequest() {
-    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", false, null);
+    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", false, null, null);
   }
 
   public static Map<String, List<WeeklyTodosResponse>> weeklyTodosMapWith(
@@ -97,6 +98,7 @@ class ToDoBuilder {
         .isCompleted(isCompleted)
         .isDeleted(false)
         .isImportant(isImportant)
+        .category(ToDoCategory.URGENT)
         .routine(null)
         .build();
   }

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -110,7 +110,7 @@ class ToDoControllerTest {
             .build();
 
     CreateToDoRequest request =
-        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", false, routineDto);
+        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", false, null, routineDto);
 
     Routine domainRoutine =
         Routine.of(
@@ -119,7 +119,8 @@ class ToDoControllerTest {
             Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY));
 
     CreateToDoCommand command =
-        new CreateToDoCommand("user-1", "goal-1", "할 일 내용", LocalDate.now(), false, domainRoutine);
+        new CreateToDoCommand(
+            "user-1", "goal-1", "할 일 내용", LocalDate.now(), false, null, domainRoutine);
     ToDoResult result = new ToDoResult("todo-1");
     ToDoResponse response = new ToDoResponse("todo-1");
 
@@ -158,6 +159,11 @@ class ToDoControllerTest {
                             fieldWithPath("isImportant")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("중요도 여부"),
+                            fieldWithPath("category")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description(
+                                    "ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -216,7 +222,7 @@ class ToDoControllerTest {
             duration, RepeatType.BIWEEKLY, Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.FRIDAY));
     UpdateToDoRequest request =
         new UpdateToDoRequest(
-            "goal-1", LocalDate.now(), "수정된 할 일 내용", true, routineDto, RoutineUpdateType.ALL);
+            "goal-1", LocalDate.now(), "수정된 할 일 내용", true, null, routineDto, RoutineUpdateType.ALL);
     UpdateToDoCommand command =
         new UpdateToDoCommand(
             todoId,
@@ -225,6 +231,7 @@ class ToDoControllerTest {
             "수정된 할 일 내용",
             LocalDate.now(),
             true,
+            null,
             routine,
             RoutineUpdateType.ALL);
 
@@ -268,6 +275,11 @@ class ToDoControllerTest {
                             fieldWithPath("isImportant")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("수정할 중요도 여부"),
+                            fieldWithPath("category")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description(
+                                    "수정할 ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -322,6 +334,7 @@ class ToDoControllerTest {
             LocalDate.of(2024, 1, 1),
             "Updated routine task",
             true,
+            null,
             routineDto,
             RoutineUpdateType.FROM_DATE);
 
@@ -333,6 +346,7 @@ class ToDoControllerTest {
             "Updated routine task",
             LocalDate.of(2024, 1, 1),
             true,
+            null,
             null,
             RoutineUpdateType.FROM_DATE);
     ToDoResult result = new ToDoResult("todo-123");
@@ -541,6 +555,11 @@ class ToDoControllerTest {
                             fieldWithPath("data[].todo.isCompleted")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("완료 여부"),
+                            fieldWithPath("data[].todo.category")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description(
+                                    "ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("data[].todo.routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -637,6 +656,11 @@ class ToDoControllerTest {
                             fieldWithPath("data.isImportant")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("중요도 여부"),
+                            fieldWithPath("data.category")
+                                .type(JsonFieldType.STRING)
+                                .optional()
+                                .description(
+                                    "ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("data.routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()

--- a/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
+++ b/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
@@ -49,7 +49,13 @@ class RoutineServiceTest {
 
     createCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Daily routine task", LocalDate.of(2024, 1, 1), true, routine);
+            "user123",
+            "goal123",
+            "Daily routine task",
+            LocalDate.of(2024, 1, 1),
+            true,
+            null,
+            routine);
 
     updateCommand =
         new UpdateToDoCommand(
@@ -59,6 +65,7 @@ class RoutineServiceTest {
             "Updated routine task",
             LocalDate.of(2024, 1, 3),
             true,
+            null,
             routine,
             RoutineUpdateType.FROM_DATE);
 
@@ -124,6 +131,7 @@ class RoutineServiceTest {
             "Updated all routine tasks",
             LocalDate.of(2024, 1, 3),
             true,
+            null,
             routine,
             RoutineUpdateType.ALL);
 
@@ -155,6 +163,7 @@ class RoutineServiceTest {
             "Updated single task",
             LocalDate.of(2024, 1, 3),
             true,
+            null,
             null, // 루틴 제거
             RoutineUpdateType.SINGLE);
 
@@ -182,6 +191,7 @@ class RoutineServiceTest {
             "Weekly routine task",
             LocalDate.of(2024, 1, 1),
             true,
+            null,
             weeklyRoutine);
 
     // When
@@ -224,6 +234,7 @@ class RoutineServiceTest {
             "Weekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
             true,
+            null,
             weeklyRoutineWithDays);
 
     // When
@@ -253,6 +264,7 @@ class RoutineServiceTest {
             "Biweekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
             true,
+            null,
             biweeklyRoutine);
 
     // When
@@ -281,6 +293,7 @@ class RoutineServiceTest {
             "Weekly routine without specific days",
             LocalDate.of(2024, 1, 1), // 월요일
             true,
+            null,
             weeklyRoutineWithoutDays);
 
     // When
@@ -310,6 +323,7 @@ class RoutineServiceTest {
             "Daily routine with repeatDays",
             LocalDate.of(2024, 1, 1),
             true,
+            null,
             dailyRoutineWithDays);
 
     // When

--- a/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
@@ -48,7 +48,8 @@ class CreateToDoUseCaseTest {
     goal = GoalFixture.customGoal("goal123", "Test Goal", null);
 
     simpleCommand =
-        new CreateToDoCommand("user123", "goal123", "Simple task", LocalDate.now(), false, null);
+        new CreateToDoCommand(
+            "user123", "goal123", "Simple task", LocalDate.now(), false, null, null);
 
     RoutineDuration duration =
         RoutineDuration.of(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7));
@@ -57,7 +58,7 @@ class CreateToDoUseCaseTest {
 
     routineCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), true, routine);
+            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), true, null, routine);
   }
 
   @Test

--- a/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
@@ -51,7 +51,15 @@ class UpdateToDoUseCaseTest {
     String newContent = "수정된 내용";
     UpdateToDoCommand command =
         new UpdateToDoCommand(
-            toDo.getId(), toDo.getUserId(), toDo.getGoalId(), newContent, today, false, null, null);
+            toDo.getId(),
+            toDo.getUserId(),
+            toDo.getGoalId(),
+            newContent,
+            today,
+            false,
+            null,
+            null,
+            null);
 
     // When
     ToDoResult result = updateToDoUseCase.execute(command);


### PR DESCRIPTION
## Summary
- FE의 4-카테고리 칩(긴급/꾸준히/넘겨도/지워도) 선택값이 백엔드에 저장되지 않아 모든 ToDo가 긴급으로 표시되던 버그 수정
- 카테고리 수정도 동일 원인으로 안 되던 문제 함께 해결
- `ToDoCategory` enum(URGENT/CONSISTENT/DEFERABLE/DELETABLE)을 도메인 → 엔티티/매퍼/요청·응답 DTO → 루틴 생성까지 end-to-end로 전파
- Flyway V33으로 todos 테이블에 category 컬럼 추가 후 기존 row는 URGENT로 backfill, 이후 NOT NULL 강제
- `isImportant`(boolean)은 클라이언트 호환성을 위해 그대로 유지

## Related
- Develop base 동일 변경 PR: #444

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew :app:test --tests \"com.growit.app.todo.*\"` 49건 그린
- [x] `./gradlew spotlessApply` 적용
- [ ] 운영 배포 전 \`todos\` 테이블 사이즈 확인 (V33 backfill + SET NOT NULL이 단일 트랜잭션이라 대용량이면 다단계 분할 권장)
- [ ] FE에서 카테고리 칩 4종 모두 생성/수정 라운드트립 확인
- [ ] Swagger 문서에 \`category\` 필드 노출 확인 (TodoDto, CreateToDoRequest, UpdateToDoRequest, WeeklyTodosResponse)

## Review notes
세 개 리뷰어(OMC code-reviewer / Codex / Claude critic)가 공통으로 지적한 후속 과제:
- V33 마이그레이션을 운영 환경에서 안전하게 적용하려면 \`ADD COLUMN ... DEFAULT 'URGENT' NOT NULL\`로 단일 DDL 처리하거나 backfill과 NOT NULL 강제를 별 마이그레이션으로 분리
- \`ToDo.updateBy/updateContentOnly\`의 \`command.category() != null\` 가드는 PATCH 시맨틱을 의도한 것 — 명시적 null clear는 막혀 있으니 정책 결정 필요
- \`isImportant\`와 \`category\` 의미 중복(긴급≈isImportant=true)에 대한 canonical 결정 후속 정리 권장

본 PR은 최소-변경 원칙으로 버그 해결에만 집중. 위 항목들은 follow-up 이슈로 분리 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)