### PR TITLE
revert: drop #445 to keep main and develop reconcilable

### DIFF
--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/CreateToDoRequest.java
@@ -2,7 +2,6 @@ package com.growit.app.todo.controller.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -23,8 +22,6 @@ public class CreateToDoRequest {
   private String content;
 
   private boolean isImportant;
-
-  private ToDoCategory category;
 
   private RoutineDto routine;
 

--- a/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/request/UpdateToDoRequest.java
@@ -3,7 +3,6 @@ package com.growit.app.todo.controller.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.controller.dto.response.RoutineDto;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -25,8 +24,6 @@ public class UpdateToDoRequest {
 
   @JsonProperty("isImportant")
   private Boolean important; // Use Boolean wrapper to allow null values
-
-  private ToDoCategory category; // nullable
 
   private RoutineDto routine; // nullable
   private RoutineUpdateType routineUpdateType; // nullable

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/TodoDto.java
@@ -1,7 +1,6 @@
 package com.growit.app.todo.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,8 +19,6 @@ public class TodoDto {
 
   @JsonProperty("isCompleted")
   private boolean completed;
-
-  private ToDoCategory category;
 
   private RoutineDto routine;
 }

--- a/app/src/main/java/com/growit/app/todo/controller/dto/response/WeeklyTodosResponse.java
+++ b/app/src/main/java/com/growit/app/todo/controller/dto/response/WeeklyTodosResponse.java
@@ -3,7 +3,6 @@ package com.growit.app.todo.controller.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.growit.app.todo.domain.ToDo;
 import com.growit.app.todo.domain.vo.Routine;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,8 +20,6 @@ public class WeeklyTodosResponse {
   @JsonProperty("isImportant")
   private boolean important;
 
-  private ToDoCategory category;
-
   private Routine routine;
 
   public static WeeklyTodosResponse from(ToDo todo) {
@@ -33,7 +30,6 @@ public class WeeklyTodosResponse {
         .content(todo.getContent())
         .completed(todo.isCompleted())
         .important(todo.isImportant())
-        .category(todo.getCategory())
         .routine(todo.getRoutine())
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoRequestMapper.java
@@ -19,7 +19,6 @@ public class ToDoRequestMapper {
         request.getContent(),
         request.getDate(),
         request.isImportant(),
-        request.getCategory(),
         toDomainRoutine(request.getRoutine()));
   }
 
@@ -31,7 +30,6 @@ public class ToDoRequestMapper {
         request.getContent(),
         request.getDate(),
         request.getImportant() != null ? request.getImportant() : false,
-        request.getCategory(),
         toDomainRoutine(request.getRoutine()),
         request.getRoutine() != null && request.getRoutineUpdateType() == null
             ? RoutineUpdateType.ALL

--- a/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
+++ b/app/src/main/java/com/growit/app/todo/controller/mapper/ToDoResponseMapper.java
@@ -28,7 +28,6 @@ public class ToDoResponseMapper {
         .content(todo.getContent())
         .important(todo.isImportant())
         .completed(todo.isCompleted())
-        .category(todo.getCategory())
         .routine(toRoutineDto(todo.getRoutine()))
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/domain/ToDo.java
+++ b/app/src/main/java/com/growit/app/todo/domain/ToDo.java
@@ -6,7 +6,6 @@ import com.growit.app.common.util.IDGenerator;
 import com.growit.app.todo.domain.dto.CreateToDoCommand;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.vo.Routine;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,8 +26,6 @@ public class ToDo {
   @JsonProperty("isImportant")
   private boolean isImportant;
 
-  private ToDoCategory category;
-
   private Routine routine;
 
   public static ToDo from(CreateToDoCommand command) {
@@ -41,7 +38,6 @@ public class ToDo {
         .isCompleted(false)
         .isDeleted(false)
         .isImportant(command.isImportant())
-        .category(command.category() != null ? command.category() : ToDoCategory.URGENT)
         .routine(command.routine())
         .build();
   }
@@ -51,9 +47,6 @@ public class ToDo {
     this.goalId = command.goalId();
     this.content = command.content();
     this.isImportant = command.isImportant();
-    if (command.category() != null) {
-      this.category = command.category();
-    }
     this.routine = command.routine();
   }
 
@@ -63,9 +56,6 @@ public class ToDo {
     this.goalId = command.goalId();
     this.content = command.content();
     this.isImportant = command.isImportant();
-    if (command.category() != null) {
-      this.category = command.category();
-    }
     // routine은 변경하지 않음
   }
 

--- a/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/CreateToDoCommand.java
@@ -1,7 +1,6 @@
 package com.growit.app.todo.domain.dto;
 
 import com.growit.app.todo.domain.vo.Routine;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 
 public record CreateToDoCommand(
@@ -10,5 +9,4 @@ public record CreateToDoCommand(
     String content,
     LocalDate date,
     boolean isImportant,
-    ToDoCategory category,
     Routine routine) {}

--- a/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
+++ b/app/src/main/java/com/growit/app/todo/domain/dto/UpdateToDoCommand.java
@@ -2,7 +2,6 @@ package com.growit.app.todo.domain.dto;
 
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineUpdateType;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 
 public record UpdateToDoCommand(
@@ -12,6 +11,5 @@ public record UpdateToDoCommand(
     String content,
     LocalDate date,
     boolean isImportant,
-    ToDoCategory category,
     Routine routine,
     RoutineUpdateType routineUpdateType) {}

--- a/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
+++ b/app/src/main/java/com/growit/app/todo/domain/service/RoutineServiceImpl.java
@@ -8,7 +8,6 @@ import com.growit.app.todo.domain.dto.ToDoResult;
 import com.growit.app.todo.domain.dto.UpdateToDoCommand;
 import com.growit.app.todo.domain.vo.RepeatType;
 import com.growit.app.todo.domain.vo.Routine;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +29,6 @@ public class RoutineServiceImpl implements RoutineService {
         command.goalId(),
         command.content(),
         command.isImportant(),
-        command.category(),
         command.date(),
         command.routine().getDuration().getStartDate(),
         command.routine().getDuration().getEndDate());
@@ -271,7 +269,6 @@ public class RoutineServiceImpl implements RoutineService {
               command.content(),
               command.date(),
               command.isImportant(),
-              command.category(),
               command.routine());
       return createRoutineToDos(createCommand);
     } else {
@@ -282,7 +279,6 @@ public class RoutineServiceImpl implements RoutineService {
               command.content(),
               command.date(),
               command.isImportant(),
-              command.category(),
               null);
       ToDo newToDo = ToDo.from(createCommand);
       toDoRepository.saveToDo(newToDo);
@@ -297,7 +293,6 @@ public class RoutineServiceImpl implements RoutineService {
         command.goalId(),
         command.content(),
         command.isImportant(),
-        command.category(),
         command.date(),
         fromDate,
         command.routine().getDuration().getEndDate());
@@ -309,7 +304,6 @@ public class RoutineServiceImpl implements RoutineService {
       String goalId,
       String content,
       boolean isImportant,
-      ToDoCategory category,
       LocalDate baseDate,
       LocalDate startDate,
       LocalDate endDate) {
@@ -321,8 +315,7 @@ public class RoutineServiceImpl implements RoutineService {
     String firstToDoId = null;
     for (LocalDate date : dates) {
       CreateToDoCommand routineCommand =
-          new CreateToDoCommand(
-              userId, goalId, content, date, isImportant, category, sharedRoutine);
+          new CreateToDoCommand(userId, goalId, content, date, isImportant, sharedRoutine);
 
       ToDo toDo = ToDo.from(routineCommand);
       toDoRepository.saveToDo(toDo);

--- a/app/src/main/java/com/growit/app/todo/domain/vo/ToDoCategory.java
+++ b/app/src/main/java/com/growit/app/todo/domain/vo/ToDoCategory.java
@@ -1,8 +1,0 @@
-package com.growit.app.todo.domain.vo;
-
-public enum ToDoCategory {
-  URGENT,
-  CONSISTENT,
-  DEFERABLE,
-  DELETABLE
-}

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/ToDoDBMapper.java
@@ -3,7 +3,6 @@ package com.growit.app.todo.infrastructure.persistence.todo;
 import com.growit.app.todo.domain.ToDo;
 import com.growit.app.todo.domain.vo.Routine;
 import com.growit.app.todo.domain.vo.RoutineDuration;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import com.growit.app.todo.infrastructure.persistence.todo.source.entity.RoutineEntity;
 import com.growit.app.todo.infrastructure.persistence.todo.source.entity.ToDoEntity;
 import java.time.DayOfWeek;
@@ -24,7 +23,6 @@ public class ToDoDBMapper {
         .date(todo.getDate())
         .isCompleted(todo.isCompleted())
         .isImportant(todo.isImportant())
-        .category(todo.getCategory() != null ? todo.getCategory() : ToDoCategory.URGENT)
         .routineId(routineId)
         .build();
   }
@@ -41,7 +39,6 @@ public class ToDoDBMapper {
         .isCompleted(entity.isCompleted())
         .isDeleted(entity.getDeletedAt() != null)
         .isImportant(entity.isImportant())
-        .category(entity.getCategory() != null ? entity.getCategory() : ToDoCategory.URGENT)
         .routine(routine)
         .build();
   }

--- a/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
+++ b/app/src/main/java/com/growit/app/todo/infrastructure/persistence/todo/source/entity/ToDoEntity.java
@@ -2,11 +2,8 @@ package com.growit.app.todo.infrastructure.persistence.todo.source.entity;
 
 import com.growit.app.common.entity.BaseEntity;
 import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -40,10 +37,6 @@ public class ToDoEntity extends BaseEntity {
   @Column(nullable = false, columnDefinition = "boolean default false")
   private boolean isImportant;
 
-  @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 32)
-  private ToDoCategory category;
-
   @Column(nullable = true)
   private String routineId;
 
@@ -52,7 +45,6 @@ public class ToDoEntity extends BaseEntity {
     this.content = toDo.getContent();
     this.isCompleted = toDo.isCompleted();
     this.isImportant = toDo.isImportant();
-    this.category = toDo.getCategory() != null ? toDo.getCategory() : ToDoCategory.URGENT;
     this.goalId = toDo.getGoalId();
     if (toDo.getRoutine() != null) {
       this.routineId = toDo.getRoutine().getId();

--- a/app/src/main/resources/db/migration/V33__add_category_to_todos.sql
+++ b/app/src/main/resources/db/migration/V33__add_category_to_todos.sql
@@ -1,9 +1,0 @@
-ALTER TABLE todos
-    ADD category VARCHAR(32);
-
-UPDATE todos
-SET category = 'URGENT'
-WHERE category IS NULL;
-
-ALTER TABLE todos
-    ALTER COLUMN category SET NOT NULL;

--- a/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
+++ b/app/src/test/java/com/growit/app/fake/todo/ToDoFixture.java
@@ -3,7 +3,6 @@ package com.growit.app.fake.todo;
 import com.growit.app.todo.controller.dto.request.CreateToDoRequest;
 import com.growit.app.todo.controller.dto.response.WeeklyTodosResponse;
 import com.growit.app.todo.domain.ToDo;
-import com.growit.app.todo.domain.vo.ToDoCategory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
@@ -21,7 +20,7 @@ public class ToDoFixture {
   }
 
   public static CreateToDoRequest defaultCreateToDoRequest() {
-    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", false, null, null);
+    return new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 예시 내용입니다.", false, null);
   }
 
   public static Map<String, List<WeeklyTodosResponse>> weeklyTodosMapWith(
@@ -98,7 +97,6 @@ class ToDoBuilder {
         .isCompleted(isCompleted)
         .isDeleted(false)
         .isImportant(isImportant)
-        .category(ToDoCategory.URGENT)
         .routine(null)
         .build();
   }

--- a/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
+++ b/app/src/test/java/com/growit/app/todo/controller/ToDoControllerTest.java
@@ -110,7 +110,7 @@ class ToDoControllerTest {
             .build();
 
     CreateToDoRequest request =
-        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", false, null, routineDto);
+        new CreateToDoRequest("goal-1", LocalDate.now(), "할 일 내용", false, routineDto);
 
     Routine domainRoutine =
         Routine.of(
@@ -119,8 +119,7 @@ class ToDoControllerTest {
             Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY));
 
     CreateToDoCommand command =
-        new CreateToDoCommand(
-            "user-1", "goal-1", "할 일 내용", LocalDate.now(), false, null, domainRoutine);
+        new CreateToDoCommand("user-1", "goal-1", "할 일 내용", LocalDate.now(), false, domainRoutine);
     ToDoResult result = new ToDoResult("todo-1");
     ToDoResponse response = new ToDoResponse("todo-1");
 
@@ -159,11 +158,6 @@ class ToDoControllerTest {
                             fieldWithPath("isImportant")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("중요도 여부"),
-                            fieldWithPath("category")
-                                .type(JsonFieldType.STRING)
-                                .optional()
-                                .description(
-                                    "ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -222,7 +216,7 @@ class ToDoControllerTest {
             duration, RepeatType.BIWEEKLY, Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.FRIDAY));
     UpdateToDoRequest request =
         new UpdateToDoRequest(
-            "goal-1", LocalDate.now(), "수정된 할 일 내용", true, null, routineDto, RoutineUpdateType.ALL);
+            "goal-1", LocalDate.now(), "수정된 할 일 내용", true, routineDto, RoutineUpdateType.ALL);
     UpdateToDoCommand command =
         new UpdateToDoCommand(
             todoId,
@@ -231,7 +225,6 @@ class ToDoControllerTest {
             "수정된 할 일 내용",
             LocalDate.now(),
             true,
-            null,
             routine,
             RoutineUpdateType.ALL);
 
@@ -275,11 +268,6 @@ class ToDoControllerTest {
                             fieldWithPath("isImportant")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("수정할 중요도 여부"),
-                            fieldWithPath("category")
-                                .type(JsonFieldType.STRING)
-                                .optional()
-                                .description(
-                                    "수정할 ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -334,7 +322,6 @@ class ToDoControllerTest {
             LocalDate.of(2024, 1, 1),
             "Updated routine task",
             true,
-            null,
             routineDto,
             RoutineUpdateType.FROM_DATE);
 
@@ -346,7 +333,6 @@ class ToDoControllerTest {
             "Updated routine task",
             LocalDate.of(2024, 1, 1),
             true,
-            null,
             null,
             RoutineUpdateType.FROM_DATE);
     ToDoResult result = new ToDoResult("todo-123");
@@ -555,11 +541,6 @@ class ToDoControllerTest {
                             fieldWithPath("data[].todo.isCompleted")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("완료 여부"),
-                            fieldWithPath("data[].todo.category")
-                                .type(JsonFieldType.STRING)
-                                .optional()
-                                .description(
-                                    "ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("data[].todo.routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()
@@ -656,11 +637,6 @@ class ToDoControllerTest {
                             fieldWithPath("data.isImportant")
                                 .type(JsonFieldType.BOOLEAN)
                                 .description("중요도 여부"),
-                            fieldWithPath("data.category")
-                                .type(JsonFieldType.STRING)
-                                .optional()
-                                .description(
-                                    "ToDo 카테고리 (URGENT, CONSISTENT, DEFERABLE, DELETABLE)"),
                             fieldWithPath("data.routine")
                                 .type(JsonFieldType.OBJECT)
                                 .optional()

--- a/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
+++ b/app/src/test/java/com/growit/app/todo/domain/service/RoutineServiceTest.java
@@ -49,13 +49,7 @@ class RoutineServiceTest {
 
     createCommand =
         new CreateToDoCommand(
-            "user123",
-            "goal123",
-            "Daily routine task",
-            LocalDate.of(2024, 1, 1),
-            true,
-            null,
-            routine);
+            "user123", "goal123", "Daily routine task", LocalDate.of(2024, 1, 1), true, routine);
 
     updateCommand =
         new UpdateToDoCommand(
@@ -65,7 +59,6 @@ class RoutineServiceTest {
             "Updated routine task",
             LocalDate.of(2024, 1, 3),
             true,
-            null,
             routine,
             RoutineUpdateType.FROM_DATE);
 
@@ -131,7 +124,6 @@ class RoutineServiceTest {
             "Updated all routine tasks",
             LocalDate.of(2024, 1, 3),
             true,
-            null,
             routine,
             RoutineUpdateType.ALL);
 
@@ -163,7 +155,6 @@ class RoutineServiceTest {
             "Updated single task",
             LocalDate.of(2024, 1, 3),
             true,
-            null,
             null, // 루틴 제거
             RoutineUpdateType.SINGLE);
 
@@ -191,7 +182,6 @@ class RoutineServiceTest {
             "Weekly routine task",
             LocalDate.of(2024, 1, 1),
             true,
-            null,
             weeklyRoutine);
 
     // When
@@ -234,7 +224,6 @@ class RoutineServiceTest {
             "Weekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
             true,
-            null,
             weeklyRoutineWithDays);
 
     // When
@@ -264,7 +253,6 @@ class RoutineServiceTest {
             "Biweekly routine on specific days",
             LocalDate.of(2024, 1, 1), // 월요일
             true,
-            null,
             biweeklyRoutine);
 
     // When
@@ -293,7 +281,6 @@ class RoutineServiceTest {
             "Weekly routine without specific days",
             LocalDate.of(2024, 1, 1), // 월요일
             true,
-            null,
             weeklyRoutineWithoutDays);
 
     // When
@@ -323,7 +310,6 @@ class RoutineServiceTest {
             "Daily routine with repeatDays",
             LocalDate.of(2024, 1, 1),
             true,
-            null,
             dailyRoutineWithDays);
 
     // When

--- a/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/CreateToDoUseCaseTest.java
@@ -48,8 +48,7 @@ class CreateToDoUseCaseTest {
     goal = GoalFixture.customGoal("goal123", "Test Goal", null);
 
     simpleCommand =
-        new CreateToDoCommand(
-            "user123", "goal123", "Simple task", LocalDate.now(), false, null, null);
+        new CreateToDoCommand("user123", "goal123", "Simple task", LocalDate.now(), false, null);
 
     RoutineDuration duration =
         RoutineDuration.of(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7));
@@ -58,7 +57,7 @@ class CreateToDoUseCaseTest {
 
     routineCommand =
         new CreateToDoCommand(
-            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), true, null, routine);
+            "user123", "goal123", "Routine task", LocalDate.of(2024, 1, 1), true, routine);
   }
 
   @Test

--- a/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
+++ b/app/src/test/java/com/growit/app/todo/usecase/UpdateToDoUseCaseTest.java
@@ -51,15 +51,7 @@ class UpdateToDoUseCaseTest {
     String newContent = "수정된 내용";
     UpdateToDoCommand command =
         new UpdateToDoCommand(
-            toDo.getId(),
-            toDo.getUserId(),
-            toDo.getGoalId(),
-            newContent,
-            today,
-            false,
-            null,
-            null,
-            null);
+            toDo.getId(), toDo.getUserId(), toDo.getGoalId(), newContent, today, false, null, null);
 
     // When
     ToDoResult result = updateToDoUseCase.execute(command);


### PR DESCRIPTION
## Summary
PR #445 (0f2593f) revert. main에 직접 들어간 ToDoCategory 구현이 develop의 #438(다른 enum 위치/이름/V33 파일명/isImportant 정책) 과 충돌해 두 브랜치를 영구히 갈라놓고, release-please는 \`targetBranch: develop\`이라 main 단독 변경을 release PR로 변환하지 못해 결국 PROD에도 배포가 안 되는 상태였습니다.

main을 #445 머지 직전 상태로 되돌려놓고, 본 버그 수정은 develop 경로(#446 enum 정렬 + 기존 #438/#440/#441)로 일원화한 다음 develop → main 머지 PR로 같이 PROD에 올리는 것이 안전합니다.

## Why
- #445 vs #438 충돌 지점:
  - enum 위치/이름: \`domain/vo/ToDoCategory\` vs \`domain/TodoCategory\`
  - enum 값: \`URGENT/CONSISTENT/DEFERABLE/DELETABLE\` vs \`NOW/STEADY/SKIP/DELETE\` (이건 #446에서 develop 쪽을 FE에 맞춰 정렬 중)
  - V33 파일명/내용: \`add_category_to_todos.sql\` vs \`replace_is_important_with_category.sql\` → 동일 버전 번호 다른 체크섬으로 Flyway 충돌 시한폭탄
  - isImportant 정책: 유지 vs 삭제

## Follow up
1. #446 (fix/category-fe-enum-align → develop) 머지 — FE/BE enum 정렬
2. develop → main 머지 PR — #438/#440/#441 + #446을 한 번에 PROD 경로로 올리기
3. release-please가 main에 release PR 생성 → tag → cd.yml PROD 배포

## Test plan
- [x] \`git revert -m 1 0f2593f\` 클린 적용 (충돌 없음)
- [ ] CI(pr-ci.yml) 그린 확인
- [ ] 머지 후 develop → main 머지 PR 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)