### PR TITLE
fix: prepare one-shot Flyway repair Bean for prod V22/V23 recovery (hold-until-needed)

### DIFF
--- a/app/src/main/java/com/growit/app/common/config/FlywayRepairConfig.java
+++ b/app/src/main/java/com/growit/app/common/config/FlywayRepairConfig.java
@@ -1,0 +1,28 @@
+package com.growit.app.common.config;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * One-shot hotfix to realign flyway_schema_history checksums for V22/V23 on the prod database.
+ *
+ * <p>Remove in the immediate follow-up PR once the next prod deploy boots successfully. Do not keep
+ * this on main permanently: an always-on repair silently masks accidental migration edits.
+ *
+ * <p>Context: 2026-05-24 dev exhibited a FlywayValidateException at V22/V23 (fixed in PR #451 on
+ * develop). main still ships the IF NOT EXISTS variant of V22/V23, so the prod
+ * flyway_schema_history checksums may not match the jar SQL the next time cd.yml runs. Holding this
+ * PR ready means the fix is one merge + release publish away if prod fails to boot.
+ */
+@Configuration
+public class FlywayRepairConfig {
+
+  @Bean
+  public FlywayMigrationStrategy flywayMigrationStrategy() {
+    return flyway -> {
+      flyway.repair();
+      flyway.migrate();
+    };
+  }
+}


### PR DESCRIPTION
## Status: 🟡 HOLD — do not merge until prod boot status is confirmed

Sibling preparation of [#451](https://github.com/DDD-Community/DDD-12-GROWIT-BE/pull/451) (dev). This PR is **ready to deploy but intentionally on hold** until we know whether prod actually needs it.

## Why this PR exists
Dev failed to boot today with `FlywayValidateException` at V22/V23 checksum mismatch. Main may carry the same latent risk:
- `V22__add_onboarding_column_to_user_advice_status.sql` on main = `ADD COLUMN IF NOT EXISTS` variant
- `V23__add_last_conversated_at_to_chat_advice.sql` on main = same
- The prod `flyway_schema_history` row was written at whichever variant happened to be deployed at the time. If the variant doesn't match what main now ships, the next `cd.yml` release reproduces the dev failure on prod.

## What it does
Adds a one-shot `FlywayMigrationStrategy` bean that calls `flyway.repair()` then `flyway.migrate()` at boot. The same shape as PR #451. `repair()` updates only `flyway_schema_history.checksum/description` — verified at `org.flywaydb.core.internal.command.DbRepair.repairChecksumsAndDescriptions()` in Flyway 10.20.1. No business tables are touched.

## What it does NOT do
- Does not touch `application.yml` (the dormant `spring.flyway.repair-on-migrate: true` is silently ignored anyway — separate cleanup PR later).
- Does not change any migration SQL.
- Does not affect FE-BE TodoCategory alignment (out of scope; develop side handled in #451).

## Merge / release decision tree
| Prod state | Action |
|---|---|
| Prod is currently healthy | **Hold this PR.** Once a release-please train next ships, decide whether to include this. Easiest cleanup path is just closing the PR without merging if prod stays green. |
| Prod is failing to boot now | Merge → publish a release → cd.yml runs → bean auto-repairs `flyway_schema_history`. |
| Unsure | Check ECS prod service health first; default to hold. |

## Pre-merge safety checks
- [ ] Confirm prod ECS deployment state (healthy / failing)
- [ ] Confirm prod RDS has a recent snapshot before release publish
- [ ] If merged, the **immediate follow-up PR must remove this file** so repair-on-boot does not become permanent on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)